### PR TITLE
Fix errors in SVD file.

### DIFF
--- a/ADuCM350.svd
+++ b/ADuCM350.svd
@@ -1,37 +1,37 @@
-<?xml version="1.0" encoding="utf-8"?>
-<device schemaVersion="1.1" xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
-     <vendor>Analog Devices</vendor>
+<?xml version="1.0" encoding="UTF-8" ?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
+    <vendor>Analog Devices</vendor>
     <vendorID>ADI</vendorID>
-	<name>ADUCM350</name>
-	<version>0.1</version>
-	<description>Cortex-M3 Microcontroller Device</description>
+    <name>ADuCM350</name>
+    <version>0.2</version>
+    <description>Cortex-M3 Microcontroller Device, CPU clock up to 16MHz, etc. </description>
 	<addressUnitBits>8</addressUnitBits>
 	<width>32</width>
-	<series>ARMCM3</series>
+	<series>ARMCM3</series>	
 	<!-- Register Default Properties -->
 	<!-- the size of the registers is set to a bit width of 32. This can be overruled for individual peripherals and/or registers -->
 	<size>32</size>
-	<!-- the access to all registers is set to be readable and writeable. This can be overruled for individual peripherals and/or registers -->
+	<!-- the access to all registers is set to be readable and writeable. This can be overruled for individual peripherals and/or registers -->	
 	<access>read-write</access>
 	<!-- for demonstration purposes the resetValue for all registers of the device is set to be 0. This can be overruled within the description -->
 	<resetValue>0</resetValue>
 	<!-- the resetMask = 0 specifies that by default no register of this device has a defined reset value -->
 	<resetMask>0</resetMask>
-	<cpu>
-		<name>CM3</name>
-		<revision>r2p0</revision>
-		<endian>little</endian>
-		<mpuPresent>false</mpuPresent>
-		<fpuPresent>false</fpuPresent>
-		<nvicPrioBits>3</nvicPrioBits>
-		<vendorSystickConfig>false</vendorSystickConfig>
-	</cpu>
+    <cpu>                                                           <!-- details about the cpu embedded in the device -->
+        <name>CM3</name>
+        <revision>r2p1</revision>
+        <endian>little</endian>
+        <mpuPresent>false</mpuPresent>
+        <fpuPresent>false</fpuPresent>
+        <nvicPrioBits>3</nvicPrioBits>
+        <vendorSystickConfig>false</vendorSystickConfig>
+    </cpu>
 	
 <!--- This file contains 
 
 
-This software is MODIFIED for the ADuCM350 processor by 
-LabLab UG, haftungsbeschraenkt ("LabLab")  and subject to the following license agreement:
+This software is MODIFIED for the ADuCM350 processor by Paul Clarke, Soniclean  and subject to the following license agreement:
+This software is MODIFIED for the ADuCM350 processor by LabLab UG, haftungsbeschraenkt ("LabLab")  and subject to the following license agreement:
 
 
 Analog Devices, Inc. ("ADI")
@@ -94,112 +94,57 @@ In the event that Third Party Software has only been provided to you in object c
 
 
  -->
-
-<!--<device xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">-->
-
-<peripherals>
-
-
-<peripheral>
-			<name>RESET</name>
-			<description>Reset register</description>
-			<groupName>RESET</groupName>
-			<baseAddress>0x40002440</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x10</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<registers>
-				<register>
-					<name>RSTSTA</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>SWRST</name>
-							<description>Software reset. Set automatically; write 1 to clear</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>WDRST</name>
-							<description>Watchdog timeout. Set automatically; write 1 to clear</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>EXTRST</name>
-							<description>External reset. Set automatically; write 1 to clear</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>POR</name>
-							<description>Power-on reset. Set automatically; write 1 to clear</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-					</fields>
-				</register>
-      </registers>
-  </peripheral>
-  <peripheral>
+ 
+	<peripherals>
+	
+	
+		<peripheral>
 			<name>ADI_GPT0</name>
-			<description>General purpose Timer 0</description>
-			<groupName>GPT0</groupName>
+			<description>General Purpose Timer 0</description>
+			<groupName>GP Timers</groupName>
 			<baseAddress>0x40000000</baseAddress>
 			<addressBlock>
 				<offset>0</offset>
-				<size>0x20</size>
+				<size>0x28</size>
 				<usage>registers</usage>
 			</addressBlock>
 			<interrupt>
-				<name>GP-TIMER0</name>
+				<description>Timer interrupt</description>
+				<name>TIMER0</name>
 				<value>11</value>
 			</interrupt>
-			<registers>
+			<registers>	
 				<register>
-					<name>GPT0LD</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>LOAD</name>
+					<description>16-bit load value</description>
+					<addressOffset>0x00</addressOffset>
+					<size>16</size>						
 				</register>
 				<register>
-					<name>GPT0VAL</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>CURCNT</name>
+					<description>16-bit timer value. read only.</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>					
 				</register>
 				<register>
-					<name>GPT0CON</name>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000010</size>
-				<!--	<description>Control Register</description>-->
+					<name>CTL</name>
+					<description>Control Register</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
 							<name>EVENTEN</name>
-							<description>Enable time capture of an event</description>
+							<description>Enable/Disable event time capture</description>
 							<bitOffset>12</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>
 									<name>DIS</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>								
 									<name>EN</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -207,71 +152,84 @@ In the event that Third Party Software has only been provided to you in object c
 						</field>
 						<field>
 							<name>EVENT</name>
+							<description>Event Select, selects 1 of the available events.</description>
 							<bitOffset>8</bitOffset>
 							<bitWidth>4</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>WUT_SRC</name>
+									<name>WUT</name>
+									<description>- Wakeup Timer</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT0</name>
+									<description>- External interrupt 0</description>
 									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT1</name>
+									<description>- External interrupt 1</description>
 									<value>2</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT2</name>
+									<description>- External interrupt 2</description>
 									<value>3</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT3</name>
+									<description>- External interrupt 3</description>
 									<value>4</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT4</name>
+									<description>- External interrupt 4</description>
 									<value>5</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT5</name>
+									<description>- External interrupt 5</description>
 									<value>6</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT6</name>
+									<description>- External interrupt 6</description>
 									<value>7</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT7</name>
+									<description>- External interrupt 7</description>
 									<value>8</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT8</name>
+									<description>- External interrupt 8</description>
 									<value>9</value>
 								</enumeratedValue>
+<!-- Value 10 is reserved -->
 								<enumeratedValue>
-									<name>Reserved</name>
-									<value>10</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>CapTouch</name>
+									<name>CAPTOUCH</name>
+									<description>CapTouch</description>
 									<value>11</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>WDT</name>
+									<description>WatchDog Timer</description>
 									<value>12</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>Flash_controller</name>
+									<name>FLASH</name>
+									<description>Flash Controller</description>
 									<value>13</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>Timer_1</name>
+									<name>TIMER1</name>
+									<description>Timer 1</description>
 									<value>14</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>Timer_2</name>
+									<name>TIMER2</name>
+									<description>Timer 2</description>
 									<value>15</value>
 								</enumeratedValue>
 							</enumeratedValues>
@@ -283,10 +241,12 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>
 									<name>DIS</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>									
 									<name>EN</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -299,19 +259,23 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>2</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>PCLK</name>
+									<name>CLK0</name>
+									<description>Clock Source 0</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>HFOSC</name>
+									<name>CLK1</name>
+									<description>Clock Source 1</description>
 									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>LFOSC</name>
+									<name>CLK2</name>
+									<description>Clock Source 2</description>
 									<value>2</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>LFXTAL</name>
+									<name>CLK3</name>
+									<description>Clock Source 3</description>
 									<value>3</value>
 								</enumeratedValue>
 							</enumeratedValues>
@@ -323,10 +287,12 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>
 									<name>DIS</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>									
 									<name>EN</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -334,15 +300,17 @@ In the event that Third Party Software has only been provided to you in object c
 						</field>
 						<field>
 							<name>MOD</name>
-						<!--	<description>Mode</description>-->
+							<description>Mode</description>
 							<bitOffset>3</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Timer runs free</description>																	<description>Enable</description>	<description>Enable</description>	
 									<name>FREERUN</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Timer is periodic</description>
 									<name>PERIODIC</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -355,14 +323,14 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>								
 									<name>DIS</name>
 									<value>0</value>
-									<!--<description>- counter is set to count down</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>									
 									<name>EN</name>
 									<value>1</value>
-							<!--		<description>- counter is set to count up</description>-->
 								</enumeratedValue>
 							</enumeratedValues>
 						</field>
@@ -373,19 +341,22 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>2</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>If CLK source 0 or 1 Divide by 4 otherwise divide by 1</description>
 									<name>DIV1</name>
 									<value>0</value>
-								<!--	<description>- If the selected clock source is 0 or 1 then this setting results in a prescaler of 4.</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 16</description>								
 									<name>DIV16</name>
 									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 256</description>								
 									<name>DIV256</name>
 									<value>2</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 32768</description>								
 									<name>DIV32768</name>
 									<value>3</value>
 								</enumeratedValue>
@@ -394,18 +365,19 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>GPT0CLRI</name>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>Clear interrupt register</description>-->
+					<name>CLRINT</name>
+					<description>Clear interrupt register</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
 							<name>CAP</name>
-							<description>Clear captured event interrupt</description>
+							<description>Captured event interrupt</description>
 							<bitOffset>1</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Clear Event interrupt</description>								
 									<name>CLR</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -413,98 +385,84 @@ In the event that Third Party Software has only been provided to you in object c
 						</field>
 						<field>
 							<name>TMOUT</name>
-							<description>Clear timeout interrupt</description>
+							<description>timeout interrupt</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
+									<description>Timeout occured</description>
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
+								<enumeratedValue>
+									<description>No Timeout</description>								
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
 							</enumeratedValues>
 						</field>
 					</fields>
 				</register>
 				<register>
-					<name>GPT0CAP</name>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000010</size>
-				<!--	<description>Capture Register</description>-->
-					<fields>
-						<field>
-							<name>VALUE</name>
-					<!--		<description>Capture value</description>-->
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>CAPTURE</name>
+					<description>Capture Register</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>			
 				</register>
 				<register>
-					<name>GPT0ALD</name>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000010</size>
-				<!--	<description>Load Value, Asynchronous Register</description>-->
-					<fields>
-						<field>
-							<name>ALOAD</name>
-							<description>Value updated in the timer clock domain</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>ALOAD</name>
+					<description>16-bit load value, asynchronous</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
 				</register>
 				<register>
-					<name>GPT0AVAL</name>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000010</size>
-				<!--	<description>Counter Value, Asynchronous Register</description>-->
-					<fields>
-						<field>
-							<name>AVAL</name>
-							<description>Counter Value (current)</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>ACURCNT</name>
+					<description>16-bit timer value, asynchronous</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
 				</register>
 				<register>
-					<name>GPT0STA</name>
-					<addressOffset>0x0000001C</addressOffset>
-					<size>0x00000010</size>
-			<!--		<description>Status Register</description>-->
+					<name>STATUS</name>
+					<description>Status</description>
+					<addressOffset>0x1C</addressOffset>
+					<size>16</size>				
 					<fields>
 						<field>
 							<name>PDOK</name>
-							<description>GPTCLRI[0] is updated in the timer clock domain</description>
+							<description>GPTI Sync</description>
 							<bitOffset>7</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
+									<description>Update occuring in Timer clock domain</description>							
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
+								<enumeratedValue>
+									<description>Interrupt cleared </description>								
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>								
 						</field>
 						<field>
 							<name>BUSY</name>
-							<description>Timer busy. Check after writing GPTCON.</description>
+							<description>Timer Busy</description>
 							<bitOffset>6</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>READY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>NOT_READY</name>
+									<description>Not Ready</description>
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
-						</field>
+								<enumeratedValue>
+									<description>Ready for Commands</description>
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>	
+						</field>	
 						<field>
 							<name>CAP</name>
 							<description>Capture event pending</description>
@@ -512,14 +470,16 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
+									<description>Capture Pending</description>
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
+								<enumeratedValue>
+									<description>No Capture</description>
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>							
 						</field>
 						<field>
 							<name>TMOUT</name>
@@ -528,133 +488,124 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
+									<description>Timeout Event occurred</description>								
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
-						</field>
+								<enumeratedValue>
+									<description>Waiting for Timeout</description>								
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>								
+						</field>								
 					</fields>
 				</register>
 				<register>
-					<name>GPT0PCON</name>
-					<addressOffset>0x00000020</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>PWM Control Register</description>-->
+					<name>PWMCTL</name>
+					<description>PWM Control Register</description>
+					<addressOffset>0x20</addressOffset>
+					<size>16</size>  
 					<fields>
 						<field>
 							<name>IDLE_STATE</name>
-							<description>PWM idle state</description>
+							<description>Idle Hi/Lo</description>
 							<bitOffset>1</bitOffset>
 							<bitWidth>1</bitWidth>
-              <enumeratedValues>
+							<enumeratedValues>
 								<enumeratedValue>
-									<name>IDLE_LOW</name>
-									<value>0</value>
+									<description>Idle High</description>								
+									<name>HIGH</name>
+									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>IDLE_HIGH</name>
-									<value>1</value>
+									<description>Idle Low</description>								
+									<name>LOW</name>
+									<value>0</value>
 								</enumeratedValue>								
-							</enumeratedValues>
+							</enumeratedValues>							
 						</field>
 						<field>
 							<name>MATCH_EN</name>
-							<description>PWM match enabled</description>
+							<description>High or Toggle</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>1</bitWidth>
-              <enumeratedValues>
+							<enumeratedValues>
 								<enumeratedValue>
-									<name>PWM_TOGGLE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PWM_MATCH</name>
+									<description>PWM in Match Mode</description>
+									<name>MATCH</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
-						</field>
+								<enumeratedValue>
+									<description>PWM in Toggle Mode</description>								
+									<name>TOGGLE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>								
+						</field>	
 					</fields>
 				</register>
 				<register>
-					<name>GPT0PMAT</name>
-					<addressOffset>0x00000024</addressOffset>
-					<size>0x00000010</size>
-				<!--	<description>PWM Match Value Register</description>-->
-					<fields>
-						<field>
-							<name>MATCH_VAL</name>
-							<description>PWM Match Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>PWMMATCH</name>
+					<description>PWM Match Value</description>
+					<addressOffset>0x24</addressOffset>
+					<size>16</size>
 				</register>
 			</registers>
-  </peripheral>
-  <peripheral>
+		</peripheral>
+	<!--
+		<peripheral derived from ADI_GPT0>
+			<name>Test_GPT</name>
+			<baseAddress>0x80000000</baseAddress>
+		</peripheral>
+-->		
+		<peripheral>
 			<name>ADI_GPT1</name>
-			<description>General purpose Timer 1</description>
-			<groupName>GPT1</groupName>
+			<description>General Purpose Timer1</description>
+			<groupName>Timer1</groupName>
 			<baseAddress>0x40000400</baseAddress>
 			<addressBlock>
 				<offset>0</offset>
-				<size>0x20</size>
+				<size>0x28</size>
 				<usage>registers</usage>
 			</addressBlock>
 			<interrupt>
-				<name>GP-TIMER1</name>
+				<description>Timer 1 Interrupt</description>
+				<name>TIMER1</name>
 				<value>12</value>
 			</interrupt>
-			<registers>
+			<registers>	
 				<register>
-					<name>GPT1LD</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>16-bit load value</description>-->
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Load value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>LOAD</name>
+					<description>16-bit load value</description>
+					<addressOffset>0x00</addressOffset>
+					<size>16</size>						
 				</register>
 				<register>
-					<name>GPT1VAL</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>"16-bit timer value, read only."</description>-->
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>CURCNT</name>
+					<description>16-bit timer value. read only.</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>					
 				</register>
 				<register>
-					<name>GPT1CON</name>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>Control Register</description>-->
+					<name>CTL</name>
+					<description>Control Register</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
 							<name>EVENTEN</name>
-							<!--<description>Enable time capture of an event</description>-->
+							<description>Enable/Disable event time capture</description>
 							<bitOffset>12</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>
 									<name>DIS</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>								
 									<name>EN</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -662,82 +613,88 @@ In the event that Third Party Software has only been provided to you in object c
 						</field>
 						<field>
 							<name>EVENT</name>
-							<description>Event select range. Timer event select range (0 to 15).</description>
+							<description>Event Select, selects 1 of the available events.</description>
 							<bitOffset>8</bitOffset>
 							<bitWidth>4</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
 									<name>UART</name>
+									<description>Uart</description>
 									<value>0</value>
-								<!--	<description>UART source</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>SPI0</name>
+									<description>SPI 0</description>
 									<value>1</value>
-								<!--	<description>- SPI0</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>SPI1</name>
+									<description>SPI 1</description>
 									<value>2</value>
-							<!--		<description>- SPI 1</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>SPIH</name>
+									<description>SPI H</description>
 									<value>3</value>
-						<!--			<description>- SPIH</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>I2C_master</name>
+									<name>I2CSLAVE</name>
+									<description>I2C Slave</description>
 									<value>4</value>
-								<!--	<description>- I2C_slave</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>I2C_master</name>
+									<name>I2CMASTER</name>
+									<description>I2C Master</description>
 									<value>5</value>
-									<!--<description>- I2C master</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>I2S</name>
+									<description>I2S</description>
 									<value>6</value>
-							<!--		<description>-I2S</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>USB</name>
+									<description>USB</description>
 									<value>7</value>
-								<!--	<description>- USB</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>USB_DMA</name>
+									<name>USBDMA</name>
+									<description>USB DMA</description>
 									<value>8</value>
-								<!--	<description>- USB DMA</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>AFE_capture</name>
+									<name>AFECAPT</name>
+									<description>AFE Capture</description>
 									<value>9</value>
-								<!--	<description>- AFE capture</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>Beeper</name>
+									<name>BEEPER</name>
+									<description>Beeper</description>
 									<value>10</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>DMA_Error</name>
+									<name>DMAERR</name>
+									<description>DMA Error</description>
 									<value>11</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>DMA_done</name>
+									<name>DMADONE</name>
+									<description>DMA DONE any channel</description>
 									<value>12</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>GP_Flash_controller</name>
+									<name>GPFLASH</name>
+									<description>GP Flash Controller</description>
 									<value>13</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>Timer_0</name>
+									<name>TIMER0</name>
+									<description>Timer 0</description>
 									<value>14</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>Timer_2</name>
+									<name>TIMER2</name>
+									<description>Timer 2</description>
 									<value>15</value>
 								</enumeratedValue>
 							</enumeratedValues>
@@ -749,10 +706,12 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>
 									<name>DIS</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>									
 									<name>EN</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -765,23 +724,24 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>2</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>PCLK</name>
+									<name>CLK0</name>
+									<description>Clock Source 0</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>HFOSC</name>
+									<name>CLK1</name>
+									<description>Clock Source 1</description>
 									<value>1</value>
-									<!--<description>- 16 MHz internal oscillator</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>LFOSC</name>
+									<name>CLK2</name>
+									<description>Clock Source 2</description>
 									<value>2</value>
-								<!--	<description>- Internal 32 kHz Oscillator</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>LFXTAL</name>
+									<name>CLK3</name>
+									<description>Clock Source 3</description>
 									<value>3</value>
-									<!--<description>- External 32 kHz crystal</description>-->
 								</enumeratedValue>
 							</enumeratedValues>
 						</field>
@@ -792,10 +752,12 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>
 									<name>DIS</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>									
 									<name>EN</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -808,14 +770,14 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Timer runs free</description>																	<description>Enable</description>	<description>Enable</description>	
 									<name>FREERUN</name>
 									<value>0</value>
-									<!--<description>- counter starts at 0x0000 or 0xFFFF</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Timer is periodic</description>
 									<name>PERIODIC</name>
 									<value>1</value>
-								<!--	<description>- counter starts at LOAD value</description>-->
 								</enumeratedValue>
 							</enumeratedValues>
 						</field>
@@ -826,14 +788,14 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>								
 									<name>DIS</name>
 									<value>0</value>
-								<!--	<description>- counter is set to count down</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>									
 									<name>EN</name>
 									<value>1</value>
-								<!--	<description>- counter is set to count up</description>-->
 								</enumeratedValue>
 							</enumeratedValues>
 						</field>
@@ -844,19 +806,22 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>2</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>If CLK source 0 or 1 Divide by 4 otherwise divide by 1</description>
 									<name>DIV1</name>
 									<value>0</value>
-							<!--		<description>- If the selected clock source is 0 or 1 then this setting results in a prescaler of 4.</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 16</description>								
 									<name>DIV16</name>
 									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 256</description>								
 									<name>DIV256</name>
 									<value>2</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 32768</description>								
 									<name>DIV32768</name>
 									<value>3</value>
 								</enumeratedValue>
@@ -865,18 +830,19 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>GT1CLRI</name>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>Clear interrupt register</description> -->
+					<name>CLRINT</name>
+					<description>Clear interrupt register</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
 							<name>CAP</name>
-							<!--<description>Clear captured event interrupt</description>-->
+							<description>Captured event interrupt</description>
 							<bitOffset>1</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Clear Event interrupt</description>								
 									<name>CLR</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -884,98 +850,84 @@ In the event that Third Party Software has only been provided to you in object c
 						</field>
 						<field>
 							<name>TMOUT</name>
-						<!--	<description>Clear timeout interrupt</description>-->
+							<description>timeout interrupt</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
+									<description>Timeout occured</description>
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
+								<enumeratedValue>
+									<description>No Timeout</description>								
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
 							</enumeratedValues>
 						</field>
 					</fields>
 				</register>
 				<register>
-					<name>GPT1CAP</name>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>Capture Register</description>-->
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Capture value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>CAPTURE</name>
+					<description>Capture Register</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>			
 				</register>
 				<register>
-					<name>GPT1ALD</name>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>Load Value, Asynchronous Register</description>-->
-					<fields>
-						<field>
-							<name>ALOAD</name>
-							<description>Value updated in the timer clock domain</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>ALOAD</name>
+					<description>16-bit load value, asynchronous</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
 				</register>
 				<register>
-					<name>GPT1AVAL</name>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>Counter Value, Asynchronous Register</description>-->
-					<fields>
-						<field>
-							<name>AVAL</name>
-							<description>Counter Value (current)</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>ACURCNT</name>
+					<description>16-bit timer value, asynchronous</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
 				</register>
 				<register>
-					<name>GPT1STA</name>
-					<addressOffset>0x0000001C</addressOffset>
-					<size>0x00000010</size>
-				<!--	<description>Status Register</description>-->
+					<name>STATUS</name>
+					<description>Status</description>
+					<addressOffset>0x1C</addressOffset>
+					<size>16</size>				
 					<fields>
 						<field>
 							<name>PDOK</name>
-							<description>GPTCLRI[0] is updated in the timer clock domain</description>
+							<description>GPTI Sync</description>
 							<bitOffset>7</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
+									<description>Update occuring in Timer clock domain</description>							
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
+								<enumeratedValue>
+									<description>Interrupt cleared </description>								
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>								
 						</field>
 						<field>
 							<name>BUSY</name>
-							<description>Timer busy. Check after writing GPTCON.</description>
+							<description>Timer Busy</description>
 							<bitOffset>6</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>READY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>NOT_READY</name>
+									<description>Not Ready</description>
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
-						</field>
+								<enumeratedValue>
+									<description>Ready for Commands</description>
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>	
+						</field>	
 						<field>
 							<name>CAP</name>
 							<description>Capture event pending</description>
@@ -983,14 +935,16 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
+									<description>Capture Pending</description>
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
+								<enumeratedValue>
+									<description>No Capture</description>
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>							
 						</field>
 						<field>
 							<name>TMOUT</name>
@@ -999,133 +953,118 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
+									<description>Timeout Event occurred</description>								
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
-						</field>
+								<enumeratedValue>
+									<description>Waiting for Timeout</description>								
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>								
+						</field>								
 					</fields>
 				</register>
-        <register>
-					<name>GPT1PCON</name>
-					<addressOffset>0x00000020</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>PWM Control Register</description>-->
+				<register>
+					<name>PWMCTL</name>
+					<description>PWM Control Register</description>
+					<addressOffset>0x20</addressOffset>
+					<size>16</size>  
 					<fields>
 						<field>
 							<name>IDLE_STATE</name>
-							<description>PWM idle state</description>
+							<description>Idle Hi/Lo</description>
 							<bitOffset>1</bitOffset>
 							<bitWidth>1</bitWidth>
-              <enumeratedValues>
+							<enumeratedValues>
 								<enumeratedValue>
-									<name>IDLE_LOW</name>
-									<value>0</value>
+									<description>Idle High</description>								
+									<name>HIGH</name>
+									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>IDLE_HIGH</name>
-									<value>1</value>
+									<description>Idle Low</description>								
+									<name>LOW</name>
+									<value>0</value>
 								</enumeratedValue>								
-							</enumeratedValues>
+							</enumeratedValues>							
 						</field>
 						<field>
 							<name>MATCH_EN</name>
-							<description>PWM match enabled</description>
+							<description>High or Toggle</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>1</bitWidth>
-              <enumeratedValues>
+							<enumeratedValues>
 								<enumeratedValue>
-									<name>PWM_TOGGLE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PWM_MATCH</name>
+									<description>PWM in Match Mode</description>
+									<name>MATCH</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
-						</field>
+								<enumeratedValue>
+									<description>PWM in Toggle Mode</description>								
+									<name>TOGGLE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>								
+						</field>	
 					</fields>
 				</register>
-					<register>
-					<name>GPT1PMAT</name>
-					<addressOffset>0x00000024</addressOffset>
-					<size>0x00000010</size>
-				<!--	<description>PWM Match Value Register</description>-->
-					<fields>
-						<field>
-							<name>MATCH_VAL</name>
-							<description>PWM Match Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+				<register>
+					<name>PWMMATCH</name>
+					<description>PWM Match Value</description>
+					<addressOffset>0x24</addressOffset>
+					<size>16</size>
 				</register>
-			</registers>
+			</registers>			
 		</peripheral>
-  <peripheral>
+		<peripheral>
 			<name>ADI_GPT2</name>
-			<description>General purpose Timer 2</description>
-			<groupName>GPT2</groupName>
+			<description>General Purpose Timer2 </description>
+			<groupName>T2</groupName>
 			<baseAddress>0x40000800</baseAddress>
 			<addressBlock>
 				<offset>0</offset>
-				<size>0x20</size>
+				<size>0x28</size>
 				<usage>registers</usage>
 			</addressBlock>
-			<interrupt>
-				<name>GP-TIMER2</name>
-				<value>40</value>
-			</interrupt>
-			<registers>
+		<interrupt>
+			<name>TIMER2</name>
+			<description>TIMER 2 interrupt</description>
+			<value>40</value>
+		</interrupt>	
+			<registers>	
 				<register>
-					<name>GPT2LD</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>16-bit load value</description>-->
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Load value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>LOAD</name>
+					<description>16-bit load value</description>
+					<addressOffset>0x00</addressOffset>
+					<size>16</size>						
 				</register>
 				<register>
-					<name>GPT2VAL</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000010</size>
-					<!--<description>"16-bit timer value, read only."</description>-->
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>CURCNT</name>
+					<description>16-bit timer value. read only.</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>					
 				</register>
 				<register>
-					<name>GPT2CON</name>
-          <description>Control Register</description>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000010</size>
+					<name>CTL</name>
+					<description>Control Register</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
 							<name>EVENTEN</name>
-							<description>Enable time capture of an event</description>
+							<description>Enable/Disable event time capture</description>
 							<bitOffset>12</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>
 									<name>DIS</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>								
 									<name>EN</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -1133,89 +1072,89 @@ In the event that Third Party Software has only been provided to you in object c
 						</field>
 						<field>
 							<name>EVENT</name>
-							<description>Event select range. Timer event select range (0 to 15).</description>
+							<description>Event Select, selects 1 of the available events.</description>
 							<bitOffset>8</bitOffset>
 							<bitWidth>4</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
 									<name>EXT0</name>
+									<description>- External interrupt 0</description>
 									<value>0</value>
-							<!--		<description>- External interrupt 0</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT1</name>
+									<description>- External interrupt 1</description>
 									<value>1</value>
-								<!--	<description>- External interrupt 1</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT2</name>
+									<description>- External interrupt 2</description>
 									<value>2</value>
-								<!--	<description>- External interrupt 2</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT3</name>
+									<description>- External interrupt 3</description>
 									<value>3</value>
-								<!--	<description>- External interrupt 3</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT4</name>
+									<description>- External interrupt 4</description>
 									<value>4</value>
-							<!--		<description>- External interrupt 4</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT5</name>
+									<description>- External interrupt 5</description>
 									<value>5</value>
-						<!--			<description>- External interrupt 5</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT6</name>
+									<description>- External interrupt 6</description>
 									<value>6</value>
-							<!--		<description>- External interrupt 6</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT7</name>
+									<description>- External interrupt 7</description>
 									<value>7</value>
-									<!--<description>- External interrupt 7</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>EXT8</name>
+									<description>- External interrupt 8</description>
 									<value>8</value>
-								<!--	<description>- External interrupt 8</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>AFE_generation</name>
+									<name>AFEGEN</name>
+									<description>AFE Generate</description>
 									<value>9</value>
-								<!--	<description>- Afe: generation</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>CapTouch</name>
+									<name>CAPTOUCH</name>
+									<description>CapTouch</description>
 									<value>10</value>
-								<!--	<description>- Capacitive touch</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>RTC</name>
+									<description>Real Time Clock</description>
 									<value>11</value>
-								<!--	<description>- Realtime clock</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>AFE_cmd_Fifo</name>
+									<name>AFECMDFIFO</name>
+									<description>AFE Command Fifo</description>
 									<value>12</value>
-								<!--	<description>-AFE command fifo</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>AFE_data_fifo</name>
+									<name>AFEDATAFIFO</name>
+									<description>AFE Data Fifo</description>
 									<value>13</value>
-								<!--	<description>- AFE data fifo</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>Timer_0</name>
+									<name>TIMER0</name>
+									<description>Timer 0</description>
 									<value>14</value>
-							<!--		<description>- Timer 0</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>Timer_1</name>
+									<name>TIMER1</name>
+									<description>Timer 1</description>
 									<value>15</value>
-					<!--				<description>- Timer 1</description>-->
 								</enumeratedValue>
 							</enumeratedValues>
 						</field>
@@ -1226,10 +1165,12 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>
 									<name>DIS</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>									
 									<name>EN</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -1242,24 +1183,24 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>2</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>PCLK</name>
+									<name>CLK0</name>
+									<description>Clock Source 0</description>
 									<value>0</value>
-								<!--	<description>- Peripheral Clock</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>HFOSC</name>
+									<name>CLK1</name>
+									<description>Clock Source 1</description>
 									<value>1</value>
-									<!--<description>- 16 MHz internal oscillator</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>LFOSC</name>
+									<name>CLK2</name>
+									<description>Clock Source 2</description>
 									<value>2</value>
-									<!--<description>- Internal 32 kHz Oscillator</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>LFXTAL</name>
+									<name>CLK3</name>
+									<description>Clock Source 3</description>
 									<value>3</value>
-									<!--<description>- External 32 kHz crystal</description>-->
 								</enumeratedValue>
 							</enumeratedValues>
 						</field>
@@ -1270,10 +1211,12 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>
 									<name>DIS</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>									
 									<name>EN</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -1286,14 +1229,14 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Timer runs free</description>																	<description>Enable</description>	<description>Enable</description>	
 									<name>FREERUN</name>
 									<value>0</value>
-									<!--<description>- counter starts at 0x0000 or 0xFFFF</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Timer is periodic</description>
 									<name>PERIODIC</name>
 									<value>1</value>
-						<!--			<description>- counter starts at LOAD value</description>-->
 								</enumeratedValue>
 							</enumeratedValues>
 						</field>
@@ -1304,37 +1247,40 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Disable</description>								
 									<name>DIS</name>
 									<value>0</value>
-									<!--<description>- counter is set to count down</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Enable</description>									
 									<name>EN</name>
 									<value>1</value>
-							<!--		<description>- counter is set to count up</description>-->
 								</enumeratedValue>
 							</enumeratedValues>
 						</field>
 						<field>
 							<name>PRE</name>
-							<!--<description>Prescaler</description>-->
+							<description>Prescaler</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>2</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>If CLK source 0 or 1 Divide by 4 otherwise divide by 1</description>
 									<name>DIV1</name>
 									<value>0</value>
-								<!--	<description>- If the selected clock source is 0 or 1 then this setting results in a prescaler of 4.</description>-->
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 16</description>								
 									<name>DIV16</name>
 									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 256</description>								
 									<name>DIV256</name>
 									<value>2</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 32768</description>								
 									<name>DIV32768</name>
 									<value>3</value>
 								</enumeratedValue>
@@ -1343,18 +1289,19 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>GPT2CLRI</name>
+					<name>CLRINT</name>
 					<description>Clear interrupt register</description>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000010</size>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
 							<name>CAP</name>
-							<!--<description>Clear captured event interrupt</description>-->
+							<description>Captured event interrupt</description>
 							<bitOffset>1</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>Clear Event interrupt</description>								
 									<name>CLR</name>
 									<value>1</value>
 								</enumeratedValue>
@@ -1362,98 +1309,84 @@ In the event that Third Party Software has only been provided to you in object c
 						</field>
 						<field>
 							<name>TMOUT</name>
-							<!--<description>Clear timeout interrupt</description>-->
+							<description>timeout interrupt</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
+									<description>Timeout occured</description>
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
+								<enumeratedValue>
+									<description>No Timeout</description>								
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
 							</enumeratedValues>
 						</field>
 					</fields>
 				</register>
 				<register>
-					<name>GPT2CAP</name>
+					<name>CAPTURE</name>
 					<description>Capture Register</description>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Capture value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>			
 				</register>
 				<register>
-					<name>GPT2ALD</name>
-					<description>Load Value, Asynchronous Register</description>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>ALOAD</name>
-							<description>Value updated in the timer clock domain</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>ALOAD</name>
+					<description>16-bit load value, asynchronous</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
 				</register>
 				<register>
-					<name>GPT2AVAL</name>
-					<description>Counter Value, Asynchronous Register</description>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>AVAL</name>
-							<description>Counter Value (current)</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>ACURCNT</name>
+					<description>16-bit timer value, asynchronous</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
 				</register>
 				<register>
-					<name>GPT2STA</name>
-					<description>Status Register</description>
-					<addressOffset>0x0000001C</addressOffset>
-					<size>0x00000010</size>
+					<name>STATUS</name>
+					<description>Status</description>
+					<addressOffset>0x1C</addressOffset>
+					<size>16</size>				
 					<fields>
 						<field>
 							<name>PDOK</name>
-							<description>GPTCLRI[0] is updated in the timer clock domain</description>
+							<description>GPTI Sync</description>
 							<bitOffset>7</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
+									<description>Update occuring in Timer clock domain</description>							
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
+								<enumeratedValue>
+									<description>Interrupt cleared </description>								
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>								
 						</field>
 						<field>
 							<name>BUSY</name>
-							<description>Timer busy. Check after writing GPTCON.</description>
+							<description>Timer Busy</description>
 							<bitOffset>6</bitOffset>
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>READY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>NOT_READY</name>
+									<description>Not Ready</description>
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
-						</field>
+								<enumeratedValue>
+									<description>Ready for Commands</description>
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>	
+						</field>	
 						<field>
 							<name>CAP</name>
 							<description>Capture event pending</description>
@@ -1461,14 +1394,16 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
+									<description>Capture Pending</description>
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
+								<enumeratedValue>
+									<description>No Capture</description>
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>							
 						</field>
 						<field>
 							<name>TMOUT</name>
@@ -1477,182 +1412,76 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
+									<description>Timeout Event occurred</description>								
+									<name>TRUE</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
-						</field>
+								<enumeratedValue>
+									<description>Waiting for Timeout</description>								
+									<name>FALSE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>								
+						</field>								
 					</fields>
 				</register>
 				<register>
-					<name>GPT2PCON</name>
-          <description>PWM Control Register</description>
-					<addressOffset>0x00000020</addressOffset>
-					<size>0x00000010</size>
+					<name>PWMCTL</name>
+					<description>PWM Control Register</description>
+					<addressOffset>0x20</addressOffset>
+					<size>16</size>  
 					<fields>
 						<field>
 							<name>IDLE_STATE</name>
-							<description>PWM idle state</description>
+							<description>Idle Hi/Lo</description>
 							<bitOffset>1</bitOffset>
 							<bitWidth>1</bitWidth>
-              <enumeratedValues>
+							<enumeratedValues>
 								<enumeratedValue>
-									<name>IDLE_LOW</name>
-									<value>0</value>
+									<description>Idle High</description>								
+									<name>HIGH</name>
+									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>IDLE_HIGH</name>
-									<value>1</value>
+									<description>Idle Low</description>								
+									<name>LOW</name>
+									<value>0</value>
 								</enumeratedValue>								
-							</enumeratedValues>
+							</enumeratedValues>							
 						</field>
 						<field>
 							<name>MATCH_EN</name>
-							<description>PWM match enabled</description>
+							<description>High or Toggle</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>1</bitWidth>
-              <enumeratedValues>
+							<enumeratedValues>
 								<enumeratedValue>
-									<name>PWM_TOGGLE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PWM_MATCH</name>
+									<description>PWM in Match Mode</description>
+									<name>MATCH</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
-						</field>
+								<enumeratedValue>
+									<description>PWM in Toggle Mode</description>								
+									<name>TOGGLE</name>
+									<value>0</value>
+								</enumeratedValue>								
+							</enumeratedValues>								
+						</field>	
 					</fields>
 				</register>
 				<register>
-					<name>GPT2PMAT</name>
-						<description>PWM Match Value Register</description>
-					<addressOffset>0x00000024</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>MATCH_VAL</name>
-							<description>PWM Match Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<name>PWMMATCH</name>
+					<description>PWM Match Value</description>
+					<addressOffset>0x24</addressOffset>
+					<size>16</size>
 				</register>
 			</registers>
 		</peripheral>
-
-  <peripheral>
-			<name>ADI_PMU</name>
-			<description>Power Management Unit</description>
-			<groupName>PMU</groupName>
-			<baseAddress>0x40002400</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x80</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<registers>
-				<register>
-					<name>PWRMOD</name>
-					<description>Power modes register</description>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000008</size>
-					<fields>
-						<field>
-							<name>RAM0_RET</name>
-							<description>Retention for RAM0</description>
-							<bitOffset>15</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS_not_retained</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN_retained</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WICENACK</name>
-							<description>WIC acknowledgement for SLEEPDEEP</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>MOD</name>
-							<description>Power Mode</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>acitve_mode</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>CORE_SLEEP_mode</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SYS_SLEEP_mode</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>hibernate_mode</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>PWRKEY</name>
-					<description>Key protection for the PWRMOD register.</description>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Key value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>KEY1</name>
-									<value>18521</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>KEY2</name>
-									<value>62075</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-			</registers>
-		</peripheral>
-		
-
-  <peripheral>  
-			<name>ADI_OSCCTRL</name>
-			<description>Oscillator Control</description>
-			<groupName>OSCCTRL</groupName>
-			<baseAddress>0x4000240C</baseAddress>
+		<peripheral>
+			<name>ADI_ID</name>
+			<description>ID </description>
+			<groupName>PWRCTL</groupName>
+			<baseAddress>0x40002020</baseAddress>
 			<addressBlock>
 				<offset>0</offset>
 				<size>0x8</size>
@@ -1660,8683 +1489,7138 @@ In the event that Third Party Software has only been provided to you in object c
 			</addressBlock>
 			<registers>
 				<register>
-					<name>OSCKEY</name>
-					<description>Write 0xCB14 to unlock the OSCCTRL register</description>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000002</size>
-					<fields>
-						<field>
-							<name>OSCKEY</name>
-							<description>unlocking key</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>UNLOCK</name>
-									<value>0xCB14</value>
-		            </enumeratedValue>
-		            <enumeratedValue>
-									<name>LOCKED</name>
-									<value>0x0</value>
-		            </enumeratedValue>
-              </enumeratedValues>
-            </field>
-          </fields>
-				</register>
-        <register>
-					<name>OSCCTRL</name>
-					<description>Oscillator Control Register (key protected)</description>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000002</size>
-					<fields>
-						<field>
-							<name>HFXTALOK</name>
-							<description>Status of HFXTAL oscillator</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>UNSTABLE</name>
-									<value>0</value>
-		            </enumeratedValue>
-		            <enumeratedValue>
-									<name>STABLE</name>
-									<value>1</value>
-		            </enumeratedValue>
-              </enumeratedValues>
-            </field>
-            <field>
-							<name>LFXTALOK</name>
-							<description>Status of LFXTAL oscillator</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>UNSTABLE</name>
-									<value>0</value>
-		            </enumeratedValue>
-		            <enumeratedValue>
-									<name>STABLE</name>
-									<value>1</value>
-		            </enumeratedValue>
-              </enumeratedValues>
-            </field>
-            <field>
-            <name>HFOSCOK</name>
-							<description>Status of HFOSC oscillator</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>UNSTABLE</name>
-									<value>0</value>
-		            </enumeratedValue>
-		            <enumeratedValue>
-									<name>STABLE</name>
-									<value>1</value>
-		            </enumeratedValue>
-              </enumeratedValues>
-            </field>
-            <field>
-							<name>LFOSCOK</name>
-							<description>Status of LFOSC oscillator</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>UNSTABLE</name>
-									<value>0</value>
-		            </enumeratedValue>
-		            <enumeratedValue>
-									<name>STABLE</name>
-									<value>1</value>
-		            </enumeratedValue>
-              </enumeratedValues>
-            </field> 
-            <field>
-							<name>HFXTALEN</name>
-							<description>HF crystal oscillator enable</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DISABLED</name>
-									<value>0</value>
-		            </enumeratedValue>
-		            <enumeratedValue>
-									<name>ENABLED</name>
-									<value>1</value>
-		            </enumeratedValue>
-              </enumeratedValues>
-            </field>            
-            <field>
-							<name>LFXTALEN</name>
-							<description>LF crystal oscillator enable</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DISABLED</name>
-									<value>0</value>
-		            </enumeratedValue>
-		            <enumeratedValue>
-									<name>ENABLED</name>
-									<value>1</value>
-		            </enumeratedValue>
-              </enumeratedValues>
-            </field>                
-            <field>
-							<name>HFOSCEN</name>
-							<description>HF internal oscillator enable</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DISABLED</name>
-									<value>0</value>
-		            </enumeratedValue>
-		            <enumeratedValue>
-									<name>ENABLED</name>
-									<value>1</value>
-		            </enumeratedValue>
-              </enumeratedValues>
-            </field>                        
-            <field>
-							<name>LFOSCEN</name>
-							<description>LF internal oscillator enable</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DISABLED</name>
-									<value>0</value>
-		            </enumeratedValue>
-		            <enumeratedValue>
-									<name>ENABLED</name>
-									<value>1</value>
-		            </enumeratedValue>
-              </enumeratedValues>
-            </field>
-          </fields>
-				</register>
-								</registers>
-          </peripheral> 
-          
-  <peripheral>
-			<name>ADI_GPIO0</name>
-			<description>General Purpose Input Output</description>
-			<groupName>GPIO0</groupName>
-			<baseAddress>0x40020000</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x28</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<registers>
-				<register>
-					<name>GP0CON</name>
-					<description>GPIO Port 0 configuration</description>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>PIN15_CFG</name>
-							<description>Configuration bits for P0.15</description>
-							<bitOffset>30</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SPIH_Chip_Select</name>
-									<value>01</value>
-               </enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PIN14_CFG</name>
-							<description>Configuration bits for P0.14</description>
-							<bitOffset>28</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SPIH_MOSI</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PIN13_CFG</name>
-							<description>Configuration bits for  P0.13</description>
-							<bitOffset>26</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SPIH_MISO</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PIN12_CFG</name>
-							<description>Configuration bits for  P0.12</description>
-							<bitOffset>24</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SPIH_SCLK</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>P11_CFG</name>
-							<description>Configuration bits for P0.11</description>
-							<bitOffset>22</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								</enumeratedValues>
-						</field>
-						<field>
-							<name>P10_CFG</name>
-							<description>Configuration bits for P0.10</description>
-							<bitOffset>20</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>Timer_C_PWM_output</name>
-									<value>01</value>
-               </enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>P9_CFG</name>
-							<description>Configuration bits for P0.9</description>
-							<bitOffset>18</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>JTAG_clock_serial_wire_clock</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>P8_CFG</name>
-							<description>Configuration bits for P0.8</description>
-							<bitOffset>16</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>JTAG_test_mode_select_SWD</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>P7_CFG</name>
-							<description>Configuration bits for P0.7</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>JTAG_serial_data_input</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>01</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>UART_RX</name>
-                <value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-            <field>
-							<name>P6_CFG</name>
-							<description>Configuration bits for P0.6</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>JTAG_serial_data_input</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>01</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>UART_TX</name>
-                <value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>P5_CFG</name>
-							<description>Configuration bits for P0.5</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>Captouch_F_down</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>P4_CFG</name>
-							<description>Configuration bits for P0.4</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>Captouch_E_up</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-            <field>
-							<name>P3_CFG</name>
-							<description>Configuration bits for P0.3</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>Captouch_D_enter</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-            <field>
-							<name>P2_CFG</name>
-							<description>Configuration bits for P0.2</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>Captouch_C_right</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-            <field>
-							<name>P1_CFG</name>
-							<description>Configuration bits for P0.1</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>Captouch_B_left</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-            <field>
-							<name>P0_CFG</name>
-							<description>Configuration bits for P0.0</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>00</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>Captouch_A_on_off</name>
-									<value>01</value>
-								</enumeratedValue>
-							</enumeratedValues>
-            </field>
-					</fields>
+					<name>ADIID</name>
+					<description>Analog Devices ID Register</description>
+					<addressOffset>0</addressOffset>
+					<size>16</size>				
 				</register>
 				<register>
-					<name>GP0OEN</name>
-          <description>GPIO Port 0 output enable register</description>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000008</size>
-					<fields>
-						<field>
-							<name>OEN15</name>
-							<description>Pin 15 output drive enable</description>
-							<bitOffset>15</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN14</name>
-							<description>Pin 14 output drive enable</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN13</name>
-							<description>Pin 13 output drive enable</description>
-							<bitOffset>13</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN12</name>
-							<description>Pin 12 output drive enable</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN11</name>
-							<description>Pin 11 output drive enable</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN10</name>
-							<description>Pin 10 output drive enable</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN9</name>
-							<description>Pin 9 output drive enable</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN8</name>
-							<description>Pin 8 output drive enable</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN7</name>
-							<description>Pin 7 output drive enable</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN6</name>
-							<description>Pin 6 output drive enable</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN5</name>
-							<description>Pin 5 output drive enable</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN4</name>
-							<description>Pin 4 output drive enable</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN3</name>
-							<description>Pin 3 output drive enable</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN2</name>
-							<description>Pin 2 output drive enable</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN1</name>
-							<description>Pin 1 output drive enable</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OEN0</name>
-							<description>Pin 0 output drive enable</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>diabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>GP0PE</name>
-          <description>GPIO Port 0 pin pull enable. Enable the pull up / pull down for the corresponding pin.</description>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000008</size>
-					<fields>
-						<field>
-							<name>PUL15</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>15</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL14</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL13</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>13</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL12</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL11</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL10</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL9</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL8</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL7</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL6</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL5</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL4</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL3</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL2</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL1</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL0</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>GP0IEN</name>
-          <description>GPIO Port 0 input path enable</description>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000008</size>
-				</register>
-				<register>
-					<name>GP0IN</name>
-					<description>GPIO Port 0 data input.</description>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000008</size>
-				</register>
-				<register>
-					<name>GP0OUT</name>
-					<description>GPIO Port 0 data out.</description>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000008</size>
-				</register>
-				<register>
-					<name>GP0SET</name>
-					<description>GPIO Port 0 data out set</description>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000008</size>
-				</register>
-				<register>
-					<name>GP0CLR</name>
-					<description>GPIO Port 0 data out clear.</description>
-					<addressOffset>0x0000001C</addressOffset>
-					<size>0x00000008</size>
-				</register>
-				<register>
-					<name>GP0TGL</name>
-					<description>GPIO Port 0 pin toggle</description>
-					<addressOffset>0x00000020</addressOffset>
-					<size>0x00000008</size>
-				</register>
-				<register>
-					<name>GP0POL</name>
-					<description>GPIO Port 0 Interrupt polarity; clear: high-&gt;low; set: low-&gt;high</description>
-					<addressOffset>0x00000024</addressOffset>
-					<size>0x00000008</size>
-				</register>
-        <register>
-					<name>GP0IENA</name>
-					<description>GPIO Port 0 Interrupt A enable</description>
-					<addressOffset>0x00000028</addressOffset>
-					<size>0x00000008</size>
-				</register>
-        <register>
-					<name>GP0IENB</name>
-					<description>GPIO Port 0 Interrupt B enable</description>
-					<addressOffset>0x00000028</addressOffset>
-					<size>0x00000008</size>
-				</register>
-				<register>
-					<name>GP0INT</name>
-					<description>GPIO Port 0 Interrupt status.  Indicates if rising/falling edge has been detected. Write 1 to clear.</description>
-					<addressOffset>0x00000030</addressOffset>
-					<size>0x00000008</size>
-				</register>
+					<name>CHIPID</name>
+					<description>Chip ID Register</description>
+					<addressOffset>4</addressOffset>
+					<size>16</size>				
+				</register>				
 			</registers>
-		</peripheral>  
-		
-  <peripheral>
-			<name>ADI_CLKCON</name>
-			<description>Clock Control</description>
-			<groupName>CLKCON</groupName>
-			<baseAddress>0x40028000</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x24</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<registers>
-				<register>
-					<name>CLKCON0</name>
-						<description>configure clock sources for various systems</description>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000016</size>
-					<fields>
-						<field>
-							<name>HFXTALIE</name>
-							<description>High frequency crystal interrupt enable</description>
-							<bitOffset>15</bitOffset>
-							<bitWidth>1</bitWidth>
+		</peripheral>			
+		<peripheral>
+		<name>ADI_PWR</name>
+		<description>Power Management Unit</description>
+		<groupName>PWRCTL</groupName>
+		<baseAddress>0x40002400</baseAddress>
+		<addressBlock>
+			<offset>0</offset>
+			<size>0x14</size>
+			<usage>registers</usage>
+		</addressBlock>
+		<registers>
+			<register>
+			<name>PWRMOD</name>
+			<description>PWR Power modes</description>
+			<addressOffset>0x00</addressOffset>
+			<size>16</size>
+			<fields>
+				<field>
+			        <name>RAM0_RET</name>
+					<description> Retention for RAM 0</description>
+					<bitOffset>15</bitOffset>
+					<bitWidth>1</bitWidth>
 							<enumeratedValues>
-								<enumeratedValue>
-									<name>DISABLED</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ENABLED</name>
-									<value>1</value>
-                </enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-						  <name>LFXTALIE</name>
-							<description>Low frequency crystal interrupt enable</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>1</bitWidth>
-								<enumeratedValues>
-								<enumeratedValue>
-									<name>DISABLED</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ENABLED</name>
-									<value>1</value>
-                </enumeratedValue>
-							</enumeratedValues>
-            </field>
-            <field>
-							<name>PLLMUX</name>
-							<description>SPLL source select mux</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>INTERNAL_RC</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EXT_XTAL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					<field>
-							<name>FIXMASTERTYPE</name>
-							<description>Force MasterType for debugger</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>LFCLKMUX</name>
-							<description>32kHz clock select mux</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>INTERNAL_32kHz_RC</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EXT_32kHz_XTAL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CLKCOUT</name>
-							<description>32kHz clock select mux</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>4</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>ROOT_CLK</name>
-									<value>0000</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LF_CLK</name>
-									<value>0001</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>CT_CLK</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HCLK_BUS</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HCLK_CORE</name>
-									<value>4</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PCLK</name>
-									<value>5</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>USBCTRLCLK</name>
-									<value>6</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>USBPHYCLK</name>
-									<value>7</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>GPT0_CLK</name>
-									<value>8</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>GPT1_CLK</name>
-									<value>9</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>GPT2_CLK</name>
-									<value>10</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>GPT2_CLK</name>
-									<value>10</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>WUT_CLK</name>
-									<value>11</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RTCCNT_CLK</name>
-									<value>12</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-              <field>
-							<name>CLKMUX</name>
-							<description>Clock mux select</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>HF_INTERNAL</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HF_EXTERNAL</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SYSTEM_PLL</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EXT_GPIO</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-          </fields>
-				</register>
-				
-				<register>
-					<name>CLKCON1</name>
-						<description>System Clocks Control Register 1 (divide rates)</description>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000016</size>
-					<fields>
-						<field>
-							<name>PCLKDIVCNT</name>
-							<description>PCLK divide count</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>6</bitWidth>
-						</field>
-						<field>
-							<name>USBCTLCLKDIVMUX</name>
-							<description>USB control clock divider mux select</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLK_HCLK</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>CLK_2xHCLK</name>
-									<value>1</value>
-								</enumeratedValue>
-								</enumeratedValues>
-						</field>
-						<field>
-							<name>HCLKDIVCNT</name>
-							<description>HCLK and CTCLK divide count</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>6</bitWidth>
-						</field>
-					</fields>
-        </register>
-				
-				<register>
-					<name>CLKCON3</name>
-					<description>System Clocks Control Register 1 (divide rates)</description>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000016</size>
-					<fields>
-						<field>
-							<name>PCLKDIVCNT</name>
-							<description>PCLK divide count</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>6</bitWidth>
-						</field>
-						<field>
-							<name>USBCTLCLKDIVMUX</name>
-							<description>USB control clock divider mux select</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLK_HCLK</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>CLK_2xHCLK</name>
-									<value>1</value>
-								</enumeratedValue>
-								</enumeratedValues>
-						</field>
-						<field>
-							<name>HCLKDIVCNT</name>
-							<description>HCLK and CTCLK divide count</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>6</bitWidth>
-						</field>
-					</fields>
-        </register>
-        <register>
-					<name>CLKCON4</name>
-					<description>USB PLL Register</description>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000016</size>
-					<fields>
-						<field>
-							<name>UPLLIE</name>
-							<description>USB PLL interrupt enable</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UPLLEN</name>
-							<description>USB PLL enable</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UPLLDIV2</name>
-							<description>USB PLL division by 2</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UPLLMSEL</name>
-							<description>USB PLL M divider</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>1</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>2</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>4</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RESERVED</name>
-									<value>3</value>
-								</enumeratedValue>
-								</enumeratedValues>
-						</field>
-						<field>
-							<name>UPLLNSEL</name>
-							<description>USB PLL N multiplier</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>5</bitWidth>
-              </field>
-					</fields>
-        </register>
-					
-<register>
-					<name>CLKCON5</name>
-					<description>User Clock Gating Control Register</description>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000016</size>
-					<fields>
-						<field>
-							<name>CTCLKOFF</name>
-							<description>CTCLK user control. This bit disables the CTCLK.</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-            <field>
-							<name>ACLKOFF</name>
-							<description>ACLK user control. This bit disables the ACLK and AFE_ADC_CLK.</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-            <field>
-							<name>UCLKI2SOFF</name>
-							<description>I2S clock user control. </description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UCLKUARTOFF</name>
-							<description>UART clock user control. </description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-              <field>
-							<name>UCLKI2COFF</name>
-							<description>I2C clock user control. </description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UCLKSPIHOFF</name>
-							<description>SPIH clock user control. </description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UCLKSPI1OFF</name>
-							<description>SPI1 clock user control. </description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UCLKSPI0OFF</name>
-							<description>SPI0 clock user control. </description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						</fields>
-						</register>
-          <register>
-					<name>CLKSTAT0</name>
-					<description>Clocking Status Register</description>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000016</size>
-					<fields>
-						<field>
-							<name>HFXTALNOK</name>
-							<description>HF crystal not stable. Successfully disabled.</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>HFXTALOK</name>
-							<description>HF crystal stable. Sticky bit. Write 1 to clear; use for interrupt.</description>
-							<bitOffset>13</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>HFXTALSTATUS</name>
-							<description>HF crystal status.</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>LFXTALNOK</name>
-							<description>LF crystal not stable. Successfully disabled.</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>LFXTALOK</name>
-							<description>LF crystal stable. Sticky bit. Write 1 to clear; use for interrupt.</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>LFXTALSTATUS</name>
-							<description>LF crystal status.</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UPLLUNLOCK</name>
-							<description>USB PLL unlock. Is set when PLL loses its lock (sticky), write 1 to clear</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UPLLLOCK</name>
-							<description>USB PLL lock. Is set when PLL locks (sticky), write 1 to clear</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>UPLLSTATUS</name>
-							<description>USB PLL status. </description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>SPLLUNLOCK</name>
-							<description>System PLL unlock. Is set when SPLL loses its lock (sticky), write 1 to clear</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>SPLLLOCK</name>
-							<description>System PLL lock. Is set when SPLL locks (sticky), write 1 to clear</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-						<field>
-							<name>SPLLSTATUS</name>
-							<description>System PLL status</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-						</field>
-        </fields>
-        </register>
-			</registers>
-  </peripheral>
-  
-  
-  <peripheral>
-			<name>ADI_INTCON0</name>
-			<description>System Control Register</description>
-			<groupName>INTCON0</groupName>
-			<baseAddress>0xE000ED10</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x4</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<registers>
-				<register>
-					<name>INTCON0</name>
-					<description>System Control Register</description>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000008</size>
-					<fields>
-						<field>
-							<name>SLEEPDEEP</name>
-							<description>Sleepdeep setting</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>not_enabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SLEEPONEXIT</name>
-							<description>Sleeponexit setting</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>not_enabled</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>enabled</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>		
-		</registers>	
-    </peripheral>
-  <peripheral>
-			<name>ADI_RESET</name>
-			<description>Reset</description>
-			<groupName>RESET</groupName>
-			<baseAddress>0x40002440</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x4</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<registers>
-				<register>
-					<name>RSTSTA</name>
-					<description>Reset Status</description>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000008</size>
-					<fields>
-						<field>
-							<name>SWRST</name>
-							<description>Software reset status bit</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WDRST</name>
-							<description>Watchdog reset status bit</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTRST</name>
-							<description>External reset status bit</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>POR</name>
-							<description>Power-on reset status bit</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>RSTCLR</name>
-					<description>Reset Status Clear</description>
-					<alternateRegister>RSTSTA</alternateRegister>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000008</size>
-					<fields>
-						<field>
-							<name>SWRST</name>
-							<description>Software reset status bit</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WDRST</name>
-							<description>Watchdog reset status bit</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTRST</name>
-							<description>External reset status bit</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>POR</name>
-							<description>Power-on reset status bit</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-			</registers>
-		</peripheral>
-  <peripheral>
-			<name>ADI_INTERRUPT</name>
-			<description>Interrupts</description>
-			<groupName>INTERRUPT</groupName>
-			<baseAddress>0x40002420</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x18</size>
-				<usage>registers</usage>
-			</addressBlock>
+						<enumeratedValue>
+							<description>Disable</description>					
+							<name>DIS</name>
+							<value>0</value>
+						</enumeratedValue>
+						<enumeratedValue>
+							<description>Enable</description>							
+							<name>EN</name>
+							<value>1</value>
+						</enumeratedValue>								
+							</enumeratedValues>	
+					</field>
+				<field>
+					<name>WICENACK</name>
+					<description>For Deepsleep mode only</description>
+					<bitOffset>3</bitOffset>
+					<bitWidth>1</bitWidth>
+					<enumeratedValues>
+						<enumeratedValue>
+							<description>Disable</description>					
+							<name>DIS</name>
+							<value>0</value>
+						</enumeratedValue>
+						<enumeratedValue>
+							<description>Enable</description>							
+							<name>EN</name>
+							<value>1</value>
+						</enumeratedValue>
+					</enumeratedValues>
+				</field>
+				<field>
+					<name>PWRMOD</name>
+					<description> Power modes control bits</description>
+					<bitOffset>0</bitOffset>		
+					<bitWidth>2</bitWidth>
+					<enumeratedValues>
+						<enumeratedValue>
+							<description>Full Active mode</description>
+							<name>FULLACTIVE</name>
+							<value>0</value>
+						</enumeratedValue>
+						<enumeratedValue>
+							<description>Core power down</description>
+							<name>CORESLEEP</name>
+							<value>1</value>
+						</enumeratedValue>
+						<enumeratedValue>
+							<description>Sleep power down</description>
+							<name>SYSSLEEP</name>
+							<value>2</value>
+						</enumeratedValue>
+						<enumeratedValue>
+							<description>Hibernate power down</description>
+							<name>HIBERNATE</name>
+							<value>3</value>
+						</enumeratedValue>
+					</enumeratedValues>
+				</field>			
+			</fields>
+			</register>
+			<register>
+			<name>PWRKEY</name>
+			<description>PWR Key protection for PWRMOD</description>
+			<addressOffset>0x04</addressOffset>
+			<size>16</size>
+			<fields>
+				<field>
+					<name>KEY</name>
+					<description>Lock for PWRMOD</description>
+					<bitOffset>0</bitOffset>		
+					<bitWidth>16</bitWidth>	
+					<writeConstraint>
+					<useEnumeratedValues>true</useEnumeratedValues>
+					</writeConstraint>
+					<enumeratedValues>
+							<enumeratedValue>
+								<description>Magic Key 1</description>
+								<name>KEY1</name>
+								<value>0x4859</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Magic Key 2</description>
+								<name>KEY2</name>
+								<value>0xf27b</value>
+							</enumeratedValue>
+						</enumeratedValues>
+				</field>
+			</fields>
+			</register>
+			<register>
+			<name>PSMCON</name>
+			<description>PWR PSM Configuration</description>
+			<addressOffset>0x08</addressOffset>
+			<size>16</size>
+			<fields>
+				<field>
+					<name>VCCMPSMSTAT</name>
+					<description> VCCM PSM current status</description>
+					<bitOffset>7</bitOffset>
+					<bitWidth>1</bitWidth>
+					<enumeratedValues>
+							<enumeratedValue>
+								<description>VCCM Power Level is Good</description>
+								<name>GOOD</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>VCCM Power Level is LOW</description>
+								<name>LOW</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>					
+				</field>
+				<field>
+					<name>VCCMPSMFLG</name>
+					<description> VCCM PSM sticky flag</description>
+					<bitOffset>6</bitOffset>
+					<bitWidth>1</bitWidth>
+					<enumeratedValues>
+							<enumeratedValue>
+								<description>VCCM Power Level is Good</description>
+								<name>GOOD</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>VCCM Power Level is LOW</description>
+								<name>LOW</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+				</field>
+				<field>
+					<name>VCCMPSMIRQ</name>
+					<description>VCCM PSM generate NMI interrupt</description>
+					<bitOffset>4</bitOffset>
+					<bitWidth>1</bitWidth>
+					<enumeratedValues>
+							<enumeratedValue>
+								<description>VCCM PSM Generate NMI </description>
+								<name>ENABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>VCMM PSM no interrrupt</description>
+								<name>DISABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>	
+				</field>
+				<field>
+				<name>DVDDPSMSTAT</name>
+					<description> DVDD PSM current status</description>
+					<bitOffset>3</bitOffset>
+					<bitWidth>1</bitWidth>
+					<enumeratedValues>
+							<enumeratedValue>
+								<description>DVDD Power Level is Good</description>
+								<name>GOOD</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>DVDD Power Level is LOW</description>
+								<name>LOW</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+				</field>
+				<field>
+					<name>DVDDPSMFLG</name>
+					<description> DVDD PSM sticky flag.</description>
+					<bitOffset>2</bitOffset>
+					<bitWidth>1</bitWidth>
+					<enumeratedValues>
+							<enumeratedValue>
+								<description>DVDD Power Level is Good</description>
+								<name>GOOD</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>DVDD Power Level is LOW</description>
+								<name>LOW</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+				</field>
+				<field>
+					<name>DVDDPSMIRQ</name>
+					<description> disable DVDD PSM to generate NMI interrupt</description>
+					<bitOffset>0</bitOffset>
+					<bitWidth>1</bitWidth>
+					<enumeratedValues>
+							<enumeratedValue>
+								<description>DVDD PSM Generate NMI </description>
+								<name>ENABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>DVDD PSM no interrrupt</description>
+								<name>DISABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+				</field>
+			</fields>
+		</register>
+		<register>
+			<name>OSCKEY</name>
+			<description>PWR Key protection for OSCCTRL</description>
+			<addressOffset>0x0C</addressOffset>
+			<size>16</size>
+			<fields>
+				<field>
+					<name>VALUE</name>
+					<description>Key value</description>
+					<bitOffset>0</bitOffset>		
+					<bitWidth>16</bitWidth>						
+					<writeConstraint>
+					<useEnumeratedValues>true</useEnumeratedValues>
+					</writeConstraint>
+					<enumeratedValues>
+						<enumeratedValue>
+							<description>Magic Key</description>
+							<name>KEY</name>
+							<value>0xCB14</value>
+						</enumeratedValue>
+					</enumeratedValues>
+				</field>
+			</fields>
+		</register>
+
+		<register>
+			<name>OSCCTRL</name>
+			<description>PWR Oscillator control</description>
+			<addressOffset>0x10</addressOffset>
+			<size>16</size>
+		</register>		
+		</registers>
+	</peripheral>
+	<peripheral>
+		<name>ADI_EI</name>
+		<description>External Interrupts</description>
+		<groupName>PWRCTL</groupName>
+		<baseAddress>0x40002420</baseAddress>
+		<addressBlock>
+			<offset>0</offset>
+			<size>0x36</size>
+			<usage>registers</usage>
+		</addressBlock>
 			<interrupt>
+				<description>External Interrupt 0</description>
 				<name>EINT0</name>
 				<value>1</value>
-			</interrupt>
+			</interrupt>		
 			<interrupt>
+				<description>External Interrupt 1</description>
 				<name>EINT1</name>
 				<value>2</value>
-			</interrupt>
+			</interrupt>		
 			<interrupt>
+				<description>External Interrupt 2</description>			
 				<name>EINT2</name>
 				<value>3</value>
-			</interrupt>
+			</interrupt>		
 			<interrupt>
+				<description>External Interrupt 3</description>			
 				<name>EINT3</name>
 				<value>4</value>
-			</interrupt>
+			</interrupt>	
 			<interrupt>
+				<description>External Interrupt 4</description>			
 				<name>EINT4</name>
 				<value>5</value>
-			</interrupt>
+			</interrupt>		
 			<interrupt>
+				<description>External Interrupt 5</description>			
 				<name>EINT5</name>
 				<value>6</value>
-			</interrupt>
+			</interrupt>		
 			<interrupt>
+				<description>External Interrupt 6</description>
 				<name>EINT6</name>
 				<value>7</value>
-			</interrupt>
+			</interrupt>		
 			<interrupt>
+				<description>External Interrupt 7</description>			
 				<name>EINT7</name>
 				<value>8</value>
 			</interrupt>
-			<registers>
-				<register>
-					<name>EI0CFG</name>
-					<description>External Interrupt configuration register 0</description>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>IRQ3EN</name>
-							<description>External Interrupt 3 Enable</description>
-							<bitOffset>15</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ3MDE</name>
-							<description>External Interrupt 0 Mode</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RISE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FALL</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RISEORFALL</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGHLEVEL</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LOWLEVEL</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ2EN</name>
-							<description>External Interrupt 2 Enable</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ2MDE</name>
-							<description>External Interrupt 2 Mode</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RISE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FALL</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RISEORFALL</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGHLEVEL</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LOWLEVEL</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ1EN</name>
-							<description>External Interrupt 1 Enable</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ1MDE</name>
-							<description>External Interrupt 1 Mode</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RISE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FALL</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RISEORFALL</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGHLEVEL</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LOWLEVEL</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ0EN</name>
-							<description>External Interrupt 0 Enable</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ0MDE</name>
-							<description>External Interrupt 0 Mode</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RISE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FALL</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RISEORFALL</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGHLEVEL</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LOWLEVEL</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>EI1CFG</name>
-					<description>External Interrupt configuration register 1</description>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>IRQ7EN</name>
-							<description>External Interrupt 7 Enable</description>
-							<bitOffset>15</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ7MDE</name>
-							<description>External Interrupt 7 Mode</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RISE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FALL</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RISEORFALL</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGHLEVEL</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LOWLEVEL</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ6EN</name>
-							<description>External Interrupt 6 Enable</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ6MDE</name>
-							<description>External Interrupt 6 Mode</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RISE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FALL</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RISEORFALL</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGHLEVEL</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LOWLEVEL</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ5EN</name>
-							<description>External Interrupt 5 Enable</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ5MDE</name>
-							<description>External Interrupt 5 Mode</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RISE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FALL</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RISEORFALL</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGHLEVEL</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LOWLEVEL</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ4EN</name>
-							<description>External Interrupt 4 Enable</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ4MDE</name>
-							<description>External Interrupt 4 Mode</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RISE</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FALL</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RISEORFALL</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGHLEVEL</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LOWLEVEL</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>EICLR</name>
-						<description>External Interrupts Clear register</description>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>IRQ7</name>
-							<description>Clears External interrupt 7 internal flag</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ6</name>
-							<description>Clears External interrupt 6 internal flag</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ5</name>
-							<description>Clears External interrupt 5 internal flag</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ4</name>
-							<description>Clears External interrupt 4 internal flag</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ3</name>
-							<description>Clears External interrupt 3 internal flag</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ2</name>
-							<description>Clears External interrupt 2 internal flag</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ1</name>
-							<description>Clears External interrupt 1 internal flag</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ0</name>
-							<description>Clears External interrupt 0 internal flag</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-			</registers>
-		</peripheral>
-  <peripheral>
-			<name>ADI_WDT</name>
-			<description>Watchdog Timer</description>
-			<groupName>WDT</groupName>
-			<baseAddress>0x40002580</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x1C</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<registers>
-				<register>
-					<name>T3LD</name>
-          <description>Load value.</description>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T3VAL</name>
-					<description>"Current count value, read only."</description>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T3CON</name>
-						<description>Control Register</description>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>MOD</name>
-							<description>Mode</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>FREERUN</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PERIODIC</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ENABLE</name>
-							<description>Enable</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PRE</name>
-							<description>Prescaler</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIV1</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>DIV16</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>DIV256</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>DIV4096</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ</name>
-							<description>Timer Interrupt ,</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PD</name>
-							<description>Power down clear</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T3CLRI</name>
-					<description>"Clear interrupt, write only."</description>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Clear Watchdog</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>52428</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T3STA</name>
-					<description>"Status register, read only."</description>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>LOCK</name>
-							<description>Lock status bit</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CON</name>
-							<description>T3CON write sync in progress</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>LD</name>
-							<description>T3LD write sync in progress</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CLRI</name>
-							<description>T3CLRI write sync in progress</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ</name>
-							<description>Interrupt Pending</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-			</registers>
-		</peripheral>
-  <peripheral>
+			<interrupt>
+				<description>External Interrupt 8</description>
+				<name>EINT8</name>
+				<value>9</value>
+			</interrupt>
+			<registers>		
+		<register>
+			<name>EI0CFG</name>
+			<description>PWR External Interrupt configuration 0</description>
+			<addressOffset>0x0</addressOffset>
+			<size>16</size>
+			<fields>
+				<field>
+					<name>IRQ3EN</name>
+					<description> External Interrupt 3 enable bit</description>
+					<bitOffset>15</bitOffset>
+					<bitWidth>1</bitWidth>
+						<writeConstraint>
+						<useEnumeratedValues>true</useEnumeratedValues>
+						</writeConstraint>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+				</field>
+				<field>
+					<name>IRQ3MDE</name>
+					<description> External Interrupt 3 Mode registers</description>
+					<bitOffset>12</bitOffset>
+					<bitWidth>3</bitWidth>
+						<writeConstraint>
+						<useEnumeratedValues>true</useEnumeratedValues>
+						</writeConstraint>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Rising Edge</description>
+								<name>EDGE mE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+				</field>
+				<field>
+					<name>IRQ2EN</name>
+					<description> External Interrupt 2 Enable bit</description>
+					<bitOffset>11</bitOffset>
+					<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+				</field>
+				<field>
+					<name>IRQ2MDE</name>
+					<description> External Interrupt 2 Mode registers</description>
+					<bitOffset>8</bitOffset>
+					<bitWidth>1</bitWidth>
+				</field>
+				<field>
+					<name>IRQ1EN</name>
+					<description>External Interrupt 1 Enable bit</description>
+					<bitOffset>7</bitOffset>
+					<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+				</field>
+				<field>
+					<name>IRQ1MDE</name>
+					<description>External Interrupt 1 Mode registers</description>
+					<bitOffset>4</bitOffset>
+					<bitWidth>1</bitWidth>
+				</field>
+				<field>
+					<name>IRQOEN</name>
+					<description> External Interrupt 0 Enable bit</description>
+					<bitOffset>3</bitOffset>
+					<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+				</field>
+				<field>
+					<name>IRQ0MDE</name>
+					<description> External Interrupt 0 Mode registers</description>
+					<bitOffset>0</bitOffset>
+					<bitWidth>1</bitWidth>
+				</field>
+			</fields>
+		</register>
+
+		<register>
+			<name>EI1CFG</name>
+			<description>PWR External Interrupt configuration 1</description>
+			<addressOffset>0x4</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>IRQ7EN</name>
+                    <description> External Interrupt 7 enable bit</description>
+                    <bitOffset>15</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ7MDE</name>
+                    <description> External Interrupt 7 Mode registers</description>
+                    <bitOffset>12</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>IRQ6EN</name>
+                    <description> External Interrupt 6 Enable bit</description>
+                    <bitOffset>11</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ6MDE</name>
+                    <description> External Interrupt 6 Mode registers</description>
+                    <bitOffset>8</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>IRQ5EN</name>
+                    <description> External Interrupt 5 Enable bit</description>
+                    <bitOffset>7</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ5MDE</name>
+                    <description> External Interrupt 5 Mode registers</description>
+                    <bitOffset>4</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>IRQ4EN</name>
+                    <description> External Interrupt 4 Enable bit</description>
+                    <bitOffset>3</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ4MDE</name>
+                    <description> External Interrupt 4 Mode registers</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+		</register>
+
+		<register>
+            <name>EI2CFG</name>
+			<description>PWR External Interrupt configuration 2</description>
+			<addressOffset>0x8</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>USBVBUSEN</name>
+                    <description> USB VBUS Detection Enable bit</description>
+                    <bitOffset>15</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>USBVBUSMDE</name>
+                    <description> USB VBUS Detection Mode registers</description>
+                    <bitOffset>12</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>USBDMEN</name>
+                    <description> USB DM Detection Enable bit</description>
+                    <bitOffset>11</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>USBDMMDE</name>
+                    <description> USB DM Detection Mode registers</description>
+                    <bitOffset>8</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>USBDPEN</name>
+                    <description> USB DP Detection Enable bit</description>
+                    <bitOffset>7</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>USBDPMDE</name>
+                    <description> USB DP Detection Mode registers</description>
+                    <bitOffset>4</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>IRQ8EN</name>
+                    <description> External Interrupt 8 Enable bit</description>
+                    <bitOffset>3</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ8MDE</name>
+                    <description> External Interrupt 8 Mode registers</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+		</register>
+
+		<register>
+			<name>EICLR</name>
+			<description>PWR External Interrupt clear</description>
+			<addressOffset>0x10</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>USBVBUS</name>
+                    <description> USB VBUS detection</description>
+                    <bitOffset>11</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>USBDM</name>
+                    <description> USB DM detection</description>
+                    <bitOffset>10</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>							
+                </field>
+                <field>
+                    <name>USBDP</name>
+                    <description> USB DP detection</description>
+                    <bitOffset>9</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ8</name>
+                    <description> External interrupt 8</description>
+                    <bitOffset>8</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>							
+                </field>
+                <field>
+                    <name>IRQ7</name>
+                    <description> External interrupt 7</description>
+                    <bitOffset>7</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>							
+                </field>
+                <field>
+                    <name>IRQ6</name>
+                    <description> External interrupt 6</description>
+                    <bitOffset>6</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ5</name>
+                    <description> External interrupt 5</description>
+                    <bitOffset>5</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ4</name>
+                    <description> External interrupt 4</description>
+                    <bitOffset>4</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ3</name>
+                    <description> External interrupt 3</description>
+                    <bitOffset>3</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ2</name>
+                    <description> External interrupt 2</description>
+                    <bitOffset>2</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ1</name>
+                    <description> External interrupt 1</description>
+                    <bitOffset>1</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+                <field>
+                    <name>IRQ0</name>
+                    <description> External interrupt 0</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Set to Clear</description>
+								<name>CLEAR</name>
+								<value>1</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                </field>
+            </fields>
+        </register>
+
+		<register>
+			<name>NMICLR</name>
+			<description>PWR Non-maskable interrupt clear</description>
+			<addressOffset>0x14</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>CLEAR</name>
+                    <description> NMI clear</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+					<enumeratedValues>
+						<enumeratedValue>
+							<description>CLEAR</description>
+							<name>CLEAR</name>
+							<value>1</value>
+						</enumeratedValue>
+					</enumeratedValues>
+                </field>
+            </fields>
+        </register>
+
+		<register>
+			<name>USBWKSTAT</name>
+			<description>PWR USB Wakeup Status</description>
+			<addressOffset>0x18</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>USBVBUS</name>
+                    <description> USB VBUS event status</description>
+                    <bitOffset>2</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>USBDM</name>
+                    <description> USB DM event status</description>
+                    <bitOffset>1</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>USBDP</name>
+                    <description> USB DP event status</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+        </register>
+
+		<register>
+			<name>RSTSTA</name>
+			<description>PWR Reset status</description>
+			<addressOffset>0x20</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>SWRST</name>
+                    <description> Software reset</description>
+                    <bitOffset>3</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WDRST</name>
+                    <description> Watchdog timeout</description>
+                    <bitOffset>2</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>EXTRST</name>
+                    <description> External reset</description>
+                    <bitOffset>1</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>POR</name>
+                    <description> Power-on reset</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+        </register>
+		</registers>
+	</peripheral>
+	<peripheral>
+		<name>ADI_PWRVCC</name>
+		<description>Power</description>
+		<groupName>PWRCTL</groupName>
+		<baseAddress>0x40002480</baseAddress>
+		<addressBlock>
+			<offset>0</offset>
+			<size>0x10</size>
+			<usage>registers</usage>
+		</addressBlock>
+		<registers>		
+
+		<register>
+			<name>VCCMCON</name>
+			<description>PWR VCCM Control and Status</description>
+			<addressOffset>0x8</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>VCCMTHR_HYST</name>
+                    <description> VCCM Threshold hysteresis</description>
+                    <bitOffset>8</bitOffset>
+                    <bitWidth>2</bitWidth>
+                </field>
+                <field>
+                    <name>VCCMTHR</name>
+                    <description> VCCM Threshold adjust</description>
+                    <bitOffset>4</bitOffset>
+                    <bitWidth>4</bitWidth>
+                </field>
+                <field>
+                    <name>VCCMPSMEN</name>
+                    <description> VCCM power supply monitoring enable</description>
+                    <bitOffset>1</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>LOADENABLE</name>
+                    <description> Enabling 820 ohm load</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+        </register>
+
+		<register>
+			<name>VBACKCON</name>
+			<description>PWR VBACK control and status</description>
+			<addressOffset>0xC</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>VBACKTRIP</name>
+                    <description> Vback trip point adjust</description>
+                    <bitOffset>8</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>VLTRIP</name>
+                    <description> Vlo trip hysteresis</description>
+                    <bitOffset>6</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>VLOTRIP</name>
+                    <description> Vlo trip level</description>
+                    <bitOffset>4</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>VBACKRESTORE</name>
+                    <description> VBACK Restore level</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+        </register>
+	</registers>
+</peripheral>
+		<peripheral>
 			<name>ADI_WUT</name>
-			<description>WakeUp Timer</description>
+			<description>Wake-up timer</description>
 			<groupName>WUT</groupName>
 			<baseAddress>0x40002500</baseAddress>
+			<size>16</size>
+
 			<addressBlock>
 				<offset>0</offset>
 				<size>0x44</size>
 				<usage>registers</usage>
 			</addressBlock>
+
+			<interrupt>
+				<name>WUT</name>
+				<description>Wake Up Timer interrupt</description>
+				<value>0</value>
+			</interrupt>
+			
 			<registers>
 				<register>
 					<name>T2VAL0</name>
-					<description>Current count value LSB</description>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<description>WUT Current count value - LS halfword.</description>
+					<addressOffset>0x00</addressOffset>
+					<size>16</size>
 				</register>
+
 				<register>
 					<name>T2VAL1</name>
-					<description>Current count value MSB</description>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
+					<description>WUT Current count value - MS halfword</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>
 				</register>
+
 				<register>
 					<name>T2CON</name>
-					<description>Control Register</description>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000010</size>
+					<description>WUT Control</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
-							<name>STOPINC</name>
-							<description>Stop wake up field A being updated</description>
+							<name>STOP</name>
+							<description> Disables updating field A register T2WUFA</description>
 							<bitOffset>11</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
 							<name>CLK</name>
-							<description>Clock</description>
+							<description> Clock select</description>
 							<bitOffset>9</bitOffset>
 							<bitWidth>2</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
 									<name>PCLK</name>
+									<description>PCLK (default)</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>LFXTAL</name>
+									<description>LF Crystal</description>
 									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>LFOSC</name>
+									<description>- Internal 32 kHz Oscillator</description>
 									<value>2</value>
 								</enumeratedValue>
-								<enumeratedValue>
-									<name>EXTCLK</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							</enumeratedValues>							
 						</field>
 						<field>
 							<name>WUEN</name>
-							<description>WUEN</description>
+							<description> Wakeup enable</description>
 							<bitOffset>8</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
 							<name>ENABLE</name>
-							<description>Enable</description>
+							<description>Timer enable</description>
 							<bitOffset>7</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
 							<name>MOD</name>
-							<description>Mode</description>
+							<description> Timer mode</description>
 							<bitOffset>6</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>PERIODIC</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FREERUN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
 							<name>FREEZE</name>
-							<description>Freeze</description>
+							<description> Freeze enable</description>
 							<bitOffset>3</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
 							<name>PRE</name>
-							<description>Prescaler</description>
+							<description> Prescaler</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>2</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
+									<description>If Core CLK Divide by 4 otherwise divide by 1</description>
 									<name>DIV1</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 16</description>								
 									<name>DIV16</name>
 									<value>1</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 256</description>								
 									<name>DIV256</name>
 									<value>2</value>
 								</enumeratedValue>
 								<enumeratedValue>
+									<description>Divide clock source by 32768</description>								
 									<name>DIV32768</name>
 									<value>3</value>
 								</enumeratedValue>
-							</enumeratedValues>
+							</enumeratedValues>							
 						</field>
 					</fields>
 				</register>
+
 				<register>
 					<name>T2INC</name>
-          <description>12-bit register. Wake up field A</description>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000010</size>
+					<description>WUT 12-bit interval for wakeup field A</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
-							<name>VALUE</name>
-							<description>12 bit value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>12</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2WUFB0</name>
-					<description>Wake up field B  LSB</description>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2WUFB1</name>
-          <description>Wake up field B  MSB</description>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2WUFC0</name>
-					<description>Wake up field C  LSB</description>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2WUFC1</name>
-					<description>Wake up field C  MSB</description>
-					<addressOffset>0x0000001C</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2WUFD0</name>
-					<description>Wake up field D  LSB</description>
-					<addressOffset>0x00000020</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2WUFD1</name>
-					<description>Wake up field D  MSB</description>
-					<addressOffset>0x00000024</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2IEN</name>
-          <description>Interrupt enable</description>
-					<addressOffset>0x00000028</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>ROLL</name>
-							<description>Enable interrupt on Rollover</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFD</name>
-							<description>Enable interrupt on WUFD</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFC</name>
-							<description>Enable interrupt on WUFC</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFB</name>
-							<description>Enable interrupt on WUFB</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFA</name>
-							<description>Enable interrupt on WUFA</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2STA</name>
-          <description>Status</description>
-					<addressOffset>0x0000002C</addressOffset>
-					<size>0x00000010</size>
-					<fields>
-						<field>
-							<name>CON</name>
-							<description>Sync</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>FREEZE</name>
-							<description>Timer Value Freeze</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ROLL</name>
-							<description>Rollover Interrupt</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFD</name>
-							<description>WUFD Interrupt</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFC</name>
-							<description>WUFC Interrupt</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFB</name>
-							<description>WUFB Interrupt</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFA</name>
-							<description>WUFA Interrupt</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2CLRI</name>
-					<addressOffset>0x00000030</addressOffset>
-					<size>0x00000010</size>
-					<description>Clear interrupts. Write only.</description>
-					<fields>
-						<field>
-							<name>ROLL</name>
-							<description>Clear interrupt on Rollover</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFD</name>
-							<description>Clear interrupt on WUFD</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFC</name>
-							<description>Clear interrupt on WUFC</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFB</name>
-							<description>Clear interrupt on WUFB</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WUFA</name>
-							<description>Clear interrupt on WUFA</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2WUFA0</name>
-					<addressOffset>0x0000003C</addressOffset>
-					<size>0x00000010</size>
-					<description>Wake up field A  LSB.</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>T2WUFA1</name>
-					<addressOffset>0x00000040</addressOffset>
-					<size>0x00000010</size>
-					<description>Wake up field A MSB.</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-			</registers>
-		</peripheral>
-		
-
-		
-  <peripheral>
-			<name>ADI_FEE</name>
-			<description>Flash Controller</description>
-			<groupName>FEE</groupName>
-			<baseAddress>0x40002800</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x84</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<interrupt>
-				<name>SINC2</name>
-				<value>15</value>
-			</interrupt>
-			<interrupt>
-				<name>FLASH</name>
-				<value>16</value>
-			</interrupt>
-			<registers>
-				<register>
-					<name>FEESTA</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<description>Status Register</description>
-					<fields>
-						<field>
-							<name>SIGNERR</name>
-							<description>Info space signature check on reset error</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CMDRES</name>
-							<description>Command result</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SUCCESS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PROTECTED</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>VERIFYERR</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ABORT</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WRDONE</name>
-							<description>Write Complete</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CMDDONE</name>
-							<description>Command complete</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WRBUSY</name>
-							<description>Write busy</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CMDBUSY</name>
-							<description>Command busy</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEECON0</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000010</size>
-					<description>Command Control Register</description>
-					<fields>
-						<field>
-							<name>WREN</name>
-							<description>Write enable.</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENERR</name>
-							<description>Error interrupt enable</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENCMD</name>
-							<description>Command complete interrupt enable</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEECMD</name>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000010</size>
-					<description>Command register</description>
-					<fields>
-						<field>
-							<name>CMD</name>
-							<description>Command</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>4</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>IDLE</name>
-									<value>0</value>
-									<description>- No command executed</description>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ERASEPAGE</name>
-									<value>1</value>
-									<description>- Erase Page</description>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SIGN</name>
-									<value>2</value>
-									<description>- Sign Range</description>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>MASSERASE</name>
-									<value>3</value>
-									<description>- Mass Erase User Space</description>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ABORT</name>
-									<value>4</value>
-									<description>- Abort a running command</description>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEADR0L</name>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000010</size>
-					<description>Low Page  (Lower 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEADR0H</name>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000010</size>
-					<description>Low Page  (Upper 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEADR1L</name>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000010</size>
-					<description>Hi Page  (Lower 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEADR1H</name>
-					<addressOffset>0x0000001C</addressOffset>
-					<size>0x00000010</size>
-					<description>Hi Page  (Upper 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEKEY</name>
-					<addressOffset>0x00000020</addressOffset>
-					<size>0x00000010</size>
-					<description>Key</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>USERKEY1</name>
-									<value>62550</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>USERKEY2</name>
-									<value>61731</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEPROL</name>
-					<addressOffset>0x00000028</addressOffset>
-					<size>0x00000010</size>
-					<description>Write Protection (Lower 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEPROH</name>
-					<addressOffset>0x0000002C</addressOffset>
-					<size>0x00000010</size>
-					<description>Write Protection (Upper 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEESIGL</name>
-					<addressOffset>0x00000030</addressOffset>
-					<size>0x00000010</size>
-					<description>Signature (Lower 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEESIGH</name>
-					<addressOffset>0x00000034</addressOffset>
-					<size>0x00000010</size>
-					<description>Signature (Upper 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEECON1</name>
-					<addressOffset>0x00000038</addressOffset>
-					<size>0x00000010</size>
-					<description>User Setup register</description>
-					<fields>
-						<field>
-							<name>DBG</name>
-							<description>Serial Wire debug enable ,</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEADRAL</name>
-					<addressOffset>0x00000048</addressOffset>
-					<size>0x00000010</size>
-					<description>Abort address (Lower 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEADRAH</name>
-					<addressOffset>0x0000004C</addressOffset>
-					<size>0x00000010</size>
-					<description>Abort address (Upper 16 bits)</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEAEN0</name>
-					<addressOffset>0x00000078</addressOffset>
-					<size>0x00000010</size>
-					<description>Lower 16 bits of the sys irq abort enable register.</description>
-					<fields>
-						<field>
-							<name>SINC2</name>
-							<description>TBD</description>
-							<bitOffset>15</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ADC1</name>
-							<description>TBD</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ADC0</name>
-							<description>TBD</description>
-							<bitOffset>13</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>T1</name>
-							<description>TBD</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>T0</name>
-							<description>TBD</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>T3</name>
-							<description>TBD</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTINT7</name>
-							<description>TBD</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTINT6</name>
-							<description>TBD</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTINT5</name>
-							<description>TBD</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTINT4</name>
-							<description>TBD</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTINT3</name>
-							<description>TBD</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTINT2</name>
-							<description>TBD</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTINT1</name>
-							<description>TBD</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EXTINT0</name>
-							<description>TBD</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>T2</name>
-							<description>TBD</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEAEN1</name>
-					<addressOffset>0x0000007C</addressOffset>
-					<size>0x00000010</size>
-					<description>Upper 16 bits of the sys irq abort enable register.</description>
-					<fields>
-						<field>
-							<name>DMADAC</name>
-							<description>TBD</description>
-							<bitOffset>15</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMAI2CMRX</name>
-							<description>TBD</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMAI2CMTX</name>
-							<description>TBD</description>
-							<bitOffset>13</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMAI2CSRX</name>
-							<description>TBD</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMAI2CSTX</name>
-							<description>TBD</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMAUARTRX</name>
-							<description>TBD</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMAUARTTX</name>
-							<description>TBD</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMASPI1RX</name>
-							<description>TBD</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMASPI1TX</name>
-							<description>TBD</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMAERROR</name>
-							<description>TBD</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>I2CM</name>
-							<description>TBD</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>I2CS</name>
-							<description>TBD</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SPI1</name>
-							<description>TBD</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SPI0</name>
-							<description>TBD</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>UART</name>
-							<description>TBD</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>FEE</name>
-							<description>TBD</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>FEEAEN2</name>
-					<addressOffset>0x00000080</addressOffset>
-					<size>0x00000010</size>
-					<description>Upper 32..47 bits of the sys irq abort enable register.</description>
-					<fields>
-						<field>
-							<name>PWM2</name>
-							<description>TBD</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PWM1</name>
-							<description>TBD</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PWM0</name>
-							<description>TBD</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PWMTRIP</name>
-							<description>TBD</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMASINC2</name>
-							<description>TBD</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMAADC1</name>
-							<description>TBD</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DMAADC0</name>
-							<description>TBD</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-			</registers>
-		</peripheral>
-  <peripheral>
-			<name>ADI_I2C</name>
-			<description>I2C</description>
-			<groupName>I2C</groupName>
-			<baseAddress>0x40003000</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x54</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<interrupt>
-				<name>I2CS</name>
-				<value>20</value>
-			</interrupt>
-			<interrupt>
-				<name>I2CM</name>
-				<value>21</value>
-			</interrupt>
-			<registers>
-				<register>
-					<name>I2CMCON</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<description>Master Control Register</description>
-					<fields>
-						<field>
-							<name>TXDMA</name>
-							<description>Enable master Tx DMA request</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXDMA</name>
-							<description>Enable master Rx DMA request</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENCMP</name>
-							<description>Transaction completed interrupt enable</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENNACK</name>
-							<description>ACK not received interrupt enable</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENALOST</name>
-							<description>Arbitration lost interrupt enable</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENTX</name>
-							<description>Transmit request interrupt enable</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENRX</name>
-							<description>Receive request interrupt enable</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>STRETCH</name>
-							<description>Stretch SCL</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>LOOPBACK</name>
-							<description>Internal loop back</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>COMPETE</name>
-							<description>Compete for ownership</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>MAS</name>
-							<description>Master Enable</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CMSTA</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000010</size>
-					<description>Master Status Register</description>
-					<fields>
-						<field>
-							<name>TXUR</name>
-							<description>Master Transmit FIFO underflow</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>MSTOP</name>
-							<description>STOP driven by th eI2C master</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>LINEBUSY</name>
-							<description>Line is busy</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXOF</name>
-							<description>Receive FIFO overflow</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TCOMP</name>
-							<description>Transaction completed</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>NACKDATA</name>
-							<description>Ack not received in response to data write</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>BUSY</name>
-							<description>Master Busy</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ALOST</name>
-							<description>Arbitration lost</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>NACKADDR</name>
-							<description>Ack not received in response to an address</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXREQ</name>
-							<description>Receive request</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TXREQ</name>
-							<description>Transmit request</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TXFSTA</name>
-							<description>Transmit FIFO Status</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>EMPTY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ONEBYTE</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FULL</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CMRX</name>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000008</size>
-					<description>Master Receive Data</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Receive Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CMTX</name>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000008</size>
-					<description>Master Transmit Data</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Transmit Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CMRXCNT</name>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000010</size>
-					<description>Master Receive Data Count</description>
-					<fields>
-						<field>
-							<name>EXTEND</name>
-							<description>Extended Read</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>COUNT</name>
-							<description>Receive count</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CMCRXCNT</name>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000010</size>
-					<description>Master Current Receive Data Count</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Current Receive count</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CADR0</name>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000008</size>
-					<description>1st Master Address Byte</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Address byte</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CADR1</name>
-					<addressOffset>0x0000001C</addressOffset>
-					<size>0x00000008</size>
-					<description>2nd Master Address Byte</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Address byte</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CDIV</name>
-					<addressOffset>0x00000024</addressOffset>
-					<size>0x00000010</size>
-					<description>Serial clock period divisor register</description>
-					<fields>
-						<field>
-							<name>HIGH</name>
-							<description>High Time</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-						<field>
-							<name>LOW</name>
-							<description>Low Time</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CSCON</name>
-					<addressOffset>0x00000028</addressOffset>
-					<size>0x00000010</size>
-					<description>Slave Control Register</description>
-					<fields>
-						<field>
-							<name>TXDMA</name>
-							<description>Enable slave Tx DMA request</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXDMA</name>
-							<description>Enable slave Rx DMA request</description>
-							<bitOffset>13</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENREPST</name>
-							<description>Repeated start interrupt enable</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENTX</name>
-							<description>Transmit request interrupt enable</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENRX</name>
-							<description>Receive request interrupt enable</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENSTOP</name>
-							<description>Stop condition detected interrupt enable</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>NACK</name>
-							<description>NACK next communication</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>STRETCH</name>
-							<description>Stretch SCL</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EARLYTXR</name>
-							<description>Early transmit request mode</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>GCSB</name>
-							<description>General call status bit clear</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>HGC</name>
-							<description>Hardware general Call enable</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>GC</name>
-							<description>General Call enable</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ADR10</name>
-							<description>Enable 10 bit addressing</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SLV</name>
-							<description>Slave Enable</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CSSTA</name>
-					<addressOffset>0x0000002C</addressOffset>
-					<size>0x00000010</size>
-					<description>"Slave I2C Status, Error and IRQ Register"</description>
-					<fields>
-						<field>
-							<name>START</name>
-							<description>Start and matching address</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>REPSTART</name>
-							<description>Repeated start and matching address</description>
-							<bitOffset>13</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IDMAT</name>
-							<description>Device ID matched</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>STOP</name>
-							<description>Stop after start and matching address</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>GCID</name>
-							<description>General ID</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>GCINT</name>
-							<description>General call</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>BUSY</name>
-							<description>Slave busy</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>NOACK</name>
-							<description>Ack not generated by the slave</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXOF</name>
-							<description>Receive FIFO</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXREQ</name>
-							<description>Receive</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TXREQ</name>
-							<description>Transmit</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TXUR</name>
-							<description>Transmit FIFO underflow</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TXFSEREQ</name>
-							<description>Tx FIFO status or early request</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CSRX</name>
-					<addressOffset>0x00000030</addressOffset>
-					<size>0x00000010</size>
-					<description>Slave Receive Data Register</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Receive register</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CSTX</name>
-					<addressOffset>0x00000034</addressOffset>
-					<size>0x00000010</size>
-					<description>Slave Transmit Data Register</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Transmit register</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CALT</name>
-					<addressOffset>0x00000038</addressOffset>
-					<size>0x00000010</size>
-					<description>Hardware General Call ID</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Alt register</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CID0</name>
-					<addressOffset>0x0000003C</addressOffset>
-					<size>0x00000010</size>
-					<description>1st Slave Address Device ID</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Slave ID</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CID1</name>
-					<addressOffset>0x00000040</addressOffset>
-					<size>0x00000010</size>
-					<description>2nd Slave Address Device ID</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Slave ID</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CID2</name>
-					<addressOffset>0x00000044</addressOffset>
-					<size>0x00000010</size>
-					<description>3rd Slave Address Device ID</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Slave ID</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CID3</name>
-					<addressOffset>0x00000048</addressOffset>
-					<size>0x00000010</size>
-					<description>4th Slave Address Device ID</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Slave ID</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>I2CFSTA</name>
-					<addressOffset>0x0000004C</addressOffset>
-					<size>0x00000010</size>
-					<description>Master and Slave Rx/Tx FIFO Status Register</description>
-					<fields>
-						<field>
-							<name>MFLUSH</name>
-							<description>Flush the master transmit FIFO</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SFLUSH</name>
-							<description>Flush the slave transmit FIFO</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>MRXFSTA</name>
-							<description>Master receive FIFO Status</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>EMPTY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ONEBYTE</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TWOBYTES</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>MTXFSTA</name>
-							<description>Master Transmit FIFO Status</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>EMPTY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ONEBYTE</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TWOBYTES</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SRXFSTA</name>
-							<description>Slave receive FIFO Status</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>EMPTY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ONEBYTE</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TWOBYTES</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>STXFSTA</name>
-							<description>Slave Transmit FIFO Status</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>EMPTY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ONEBYTE</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TWOBYTES</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-			</registers>
-		</peripheral>
-  <peripheral>
-			<name>ADI_SPI0</name>
-			<description>Serial Peripheral Interface</description>
-			<groupName>SPI0</groupName>
-			<baseAddress>0x40004000</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x1C</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<interrupt>
-				<name>SPI0</name>
-				<value>18</value>
-			</interrupt>
-			<registers>
-				<register>
-					<name>SPI0STA</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<description>Status Register</description>
-					<fields>
-						<field>
-							<name>CSERR</name>
-							<description>Detected an abrupt CS deassertion</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXS</name>
-							<description>Set when there are more bytes in the RX FIFO than the TIM bit says</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXFSTA</name>
-							<description>Receive FIFO Status</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>EMPTY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ONEBYTE</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TWOBYTES</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>THREEBYTES</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FOURBYTES</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXOF</name>
-							<description>Receive FIFO overflow</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RX</name>
-							<description>Set when a receive interrupt occurs</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TX</name>
-							<description>Set when a transmit interrupt occurs</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TXUR</name>
-							<description>Transmit FIFO underflow</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TXFSTA</name>
-							<description>transmit FIFO Status</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>EMPTY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ONEBYTE</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TWOBYTES</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>THREEBYTES</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FOURBYTES</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ</name>
-							<description>Interrupt status bit</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI0RX</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000008</size>
-					<description>8-bit Receive register.</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Received data</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI0TX</name>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000008</size>
-					<description>8-bit Transmit register</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Data to transmit</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI0DIV</name>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000010</size>
-					<description>SPI Clock Divider Registers</description>
-					<fields>
-						<field>
-							<name>BCRST</name>
-							<description>Bit counter reset</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DIV</name>
-							<description>Factor used to divide UCLK to generate the serial clock</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>6</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI0CON</name>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000010</size>
-					<description>16-bit configuration register</description>
-					<fields>
-						<field>
-							<name>MOD</name>
-							<description>SPI IRQ Mode bits</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TX1RX1</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TX2RX2</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TX3RX3</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TX4RX4</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TFLUSH</name>
-							<description>TX FIFO Flush Enable bit</description>
-							<bitOffset>13</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RFLUSH</name>
-							<description>RX FIFO Flush Enable bit</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CON</name>
-							<description>Continuous transfer enable</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>LOOPBACK</name>
-							<description>Loopback enable bit</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SOEN</name>
-							<description>Slave MISO output enable bit</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXOF</name>
-							<description>RX Oveflow Overwrite enable</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ZEN</name>
-							<description>Transmit zeros when empty</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TIM</name>
-							<description>Transfer and interrupt mode</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RXRD</name>
-									<value>0</value>
-									<description>- Cleared by user to initiate transfer with a read of the SPIRX register</description>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TXWR</name>
-									<value>1</value>
-									<description>- Set by user to initiate transfer with a write to the SPITX register.</description>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>LSB</name>
-							<description>LSB First Transfer enable</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WOM</name>
-							<description>Wired OR enable</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CPOL</name>
-							<description>Clock polarity mode</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CPHA</name>
-							<description>Clock phase mode</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SAMPLELEADING</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SAMPLETRAILING</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>MASEN</name>
-							<description>Master enable</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ENABLE</name>
-							<description>SPI Enable bit</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI0DMA</name>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000010</size>
-					<description>DMA enable register</description>
-					<fields>
-						<field>
-							<name>IENRXDMA</name>
-							<description>Enable receive DMA request</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENTXDMA</name>
-							<description>Enable transmit DMA request</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ENABLE</name>
-							<description>Enable DMA for data transfer</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI0CNT</name>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000010</size>
-					<description>8-bit received byte count register</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Count</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-			</registers>
-		</peripheral>
-  <peripheral>
-			<name>ADI_SPI1</name>
-			<description>Serial Peripheral Interface</description>
-			<groupName>SPI1</groupName>
-			<baseAddress>0x40004400</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x1C</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<interrupt>
-				<name>SPI1</name>
-				<value>19</value>
-			</interrupt>
-			<registers>
-				<register>
-					<name>SPI1STA</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<description>Status Register</description>
-					<fields>
-						<field>
-							<name>CSERR</name>
-							<description>Detected an abrupt CS deassertion</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXS</name>
-							<description>Set when there are more bytes in the RX FIFO than the TIM bit says</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXFSTA</name>
-							<description>Receive FIFO Status</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>EMPTY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ONEBYTE</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TWOBYTES</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>THREEBYTES</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FOURBYTES</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXOF</name>
-							<description>Receive FIFO overflow</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RX</name>
-							<description>Set when a receive interrupt occurs</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TX</name>
-							<description>Set when a transmit interrupt occurs</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TXUR</name>
-							<description>Transmit FIFO underflow</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TXFSTA</name>
-							<description>transmit FIFO Status</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>3</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>EMPTY</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>ONEBYTE</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TWOBYTES</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>THREEBYTES</name>
-									<value>3</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>FOURBYTES</name>
-									<value>4</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IRQ</name>
-							<description>Interrupt status bit</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI1RX</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000008</size>
-					<description>8-bit Receive register.</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Received data</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI1TX</name>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000008</size>
-					<description>8-bit Transmit register</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Data to transmit</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI1DIV</name>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000010</size>
-					<description>SPI Clock Divider Registers</description>
-					<fields>
-						<field>
-							<name>BCRST</name>
-							<description>Bit counter reset</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DIV</name>
-							<description>Factor used to divide UCLK to generate the serial clock</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>6</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI1CON</name>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000010</size>
-					<description>16-bit configuration register</description>
-					<fields>
-						<field>
-							<name>MOD</name>
-							<description>SPI IRQ Mode bits</description>
-							<bitOffset>14</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TX1RX1</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TX2RX2</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TX3RX3</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TX4RX4</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TFLUSH</name>
-							<description>TX FIFO Flush Enable bit</description>
-							<bitOffset>13</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RFLUSH</name>
-							<description>RX FIFO Flush Enable bit</description>
-							<bitOffset>12</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CON</name>
-							<description>Continuous transfer enable</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>LOOPBACK</name>
-							<description>Loopback enable bit</description>
-							<bitOffset>10</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SOEN</name>
-							<description>Slave MISO output enable bit</description>
-							<bitOffset>9</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RXOF</name>
-							<description>RX Oveflow Overwrite enable</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ZEN</name>
-							<description>Transmit zeros when empty</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TIM</name>
-							<description>Transfer and interrupt mode</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>RXRD</name>
-									<value>0</value>
-									<description>- Cleared by user to initiate transfer with a read of the SPIRX register</description>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TXWR</name>
-									<value>1</value>
-									<description>- Set by user to initiate transfer with a write to the SPITX register.</description>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>LSB</name>
-							<description>LSB First Transfer enable</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WOM</name>
-							<description>Wired OR enable</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CPOL</name>
-							<description>Clock polarity mode</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CPHA</name>
-							<description>Clock phase mode</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SAMPLELEADING</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SAMPLETRAILING</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>MASEN</name>
-							<description>Master enable</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ENABLE</name>
-							<description>SPI Enable bit</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI1DMA</name>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000010</size>
-					<description>DMA enable register</description>
-					<fields>
-						<field>
-							<name>IENRXDMA</name>
-							<description>Enable receive DMA request</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IENTXDMA</name>
-							<description>Enable transmit DMA request</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ENABLE</name>
-							<description>Enable DMA for data transfer</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>SPI1CNT</name>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000010</size>
-					<description>8-bit received byte count register</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Count</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-			</registers>
-		</peripheral>
-  <peripheral>
-			<name>ADI_UART0</name>
-			<description>UART0</description>
-			<groupName>UART0</groupName>
-			<baseAddress>0x40005000</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x34</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<registers>
-				<register>
-					<name>COMTX</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000008</size>
-					<description>Transmit Holding register</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>COMRX</name>
-					<alternateRegister>COMTX</alternateRegister>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000008</size>
-					<description>Receive Buffer register</description>
-					<fields>
-						<field>
-							<name>VALUE</name>
-							<description>Value</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>8</bitWidth>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>COMIEN</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000008</size>
-					<description>Interrupt Enable register</description>
-					<fields>
-						<field>
-							<name>EDMAR</name>
-							<description>Enable DMA requests in transmit mode</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EDMAT</name>
-							<description>Enable DMA requests in receive mode</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EDSSI</name>
-							<description>Enable Modem Status interrupt</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ELSI</name>
-							<description>Enable Rx status interrupt</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ETBEI</name>
-							<description>Enable transmit buffer empty interrupt</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>ERBFI</name>
-							<description>Enable receive buffer full interrupt</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>COMIIR</name>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000008</size>
-					<description>Interrupt Identification register</description>
-					<fields>
-						<field>
-							<name>STA</name>
-							<description>Status bits.</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>MODEMSTATUS</name>
-									<value>0</value>
-									<description>- Modem status interrupt.</description>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>TXBUFEMPTY</name>
-									<value>1</value>
-									<description>- Transmit buffer empty interrupt.</description>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RXBUFFULL</name>
-									<value>2</value>
-									<description>- Receive buffer full interrupt. Read RBR register to clear.</description>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>RXLINESTATUS</name>
-									<value>3</value>
-									<description>- Receive line status interrupt. Read LSR register to clear.</description>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>NINT</name>
-							<description>Interrupt flag.</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>COMLCR</name>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000008</size>
-					<description>Line Control register</description>
-					<fields>
-						<field>
-							<name>BRK</name>
-							<description>Set Break.</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SP</name>
-							<description>Stick Parity.</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>EPS</name>
-							<description>Even Parity Select Bit.</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PEN</name>
-							<description>Parity Enable Bit.</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>STOP</name>
-							<description>Stop Bit.</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>WLS</name>
-							<description>Word Length Select bits</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>5BITS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>6BITS</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>7BITS</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>8BITS</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>COMMCR</name>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000008</size>
-					<description>Module Control register</description>
-					<fields>
-						<field>
-							<name>LOOPBACK</name>
-							<description>Loop Back.</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OUT1</name>
-							<description>Parity Enable Bit.</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OUT2</name>
-							<description>Stop Bit.</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RTS</name>
-							<description>Request To Send.</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DTR</name>
-							<description>Data Terminal Ready.</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>COMLSR</name>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000008</size>
-					<description>Line Status register</description>
-					<fields>
-						<field>
-							<name>TEMT</name>
-							<description>COMTX and Shift Register Empty Status Bit.</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>THRE</name>
-							<description>COMTX Empty Status Bit.</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>BI</name>
-							<description>Break Indicator.</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>FE</name>
-							<description>Framing Error.</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PE</name>
-							<description>Parity Error.</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OE</name>
-							<description>Overrun Error.</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DR</name>
-							<description>Data Ready.</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>COMMSR</name>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000008</size>
-					<description>Modem Status register</description>
-					<fields>
-						<field>
-							<name>DCD</name>
-							<description>Data Carrier Detect.</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>RI</name>
-							<description>Ring Indicator.</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DSR</name>
-							<description>Data Set Ready.</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CTS</name>
-							<description>Clear To Send.</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DDCD</name>
-							<description>Delta DCD.</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TERI</name>
-							<description>Trailing Edge RI.</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DDSR</name>
-							<description>Delta DSR.</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DCTS</name>
-							<description>Delta CTS.</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>COMFBR</name>
-					<addressOffset>0x00000024</addressOffset>
-					<size>0x00000010</size>
-					<description>Fractional baud rate divider register.</description>
-					<fields>
-						<field>
-							<name>ENABLE</name>
-							<description>Enable</description>
-							<bitOffset>15</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>DIVM</name>
-							<description>Fractional M Divide bits</description>
-							<bitOffset>11</bitOffset>
-							<bitWidth>2</bitWidth>
-						</field>
-						<field>
-							<name>DIVN</name>
-							<description>Fractional N Divide bits</description>
+							<name>INTERVAL</name>
+							<description> Interval for wakeup field A</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>11</bitWidth>
 						</field>
 					</fields>
 				</register>
+				
 				<register>
-					<name>COMDIV</name>
-					<addressOffset>0x00000028</addressOffset>
-					<size>0x00000010</size>
-					<description>Baud rate Divisor register</description>
+					<name>T2WUFB0</name>
+					<description>WUT Wakeup field B - LS halfword</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>T2WUFB1</name>
+					<description>WUT Wakeup field B - MS halfword</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>T2WUFC0</name>
+					<description>WUT Wakeup field C - LS halfword</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>T2WUFC1</name>
+					<description>WUT Wakeup field C - MS halfword</description>
+					<addressOffset>0x1C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>T2WUFD0</name>
+					<description>WUT Wakeup field D - LS halfword</description>
+					<addressOffset>0x20</addressOffset>
+				</register>
+
+				<register>
+					<name>T2WUFD1</name>
+					<description>WUT Wakeup field D - MS halfword</description>
+					<addressOffset>0x24</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>T2IEN</name>
+					<description>WUT Interrupt enable</description>
+					<addressOffset>0x28</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
-							<name>VALUE</name>
-							<description>Sets the baudrate</description>
+							<name>ROLL</name>
+							<description> Rollover interrupt enable</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFD</name>
+							<description> T2WUFD interrupt enable</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFC</name>
+							<description> T2WUFC interrupt enable</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFB</name>
+							<description> T2WUFB interrupt enable</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFA</name>
+							<description> T2WUFA interrupt enable</description>
 							<bitOffset>0</bitOffset>
-							<bitWidth>16</bitWidth>
+							<bitWidth>1</bitWidth>
 						</field>
 					</fields>
 				</register>
+
 				<register>
-					<name>COMCON</name>
-					<addressOffset>0x00000030</addressOffset>
-					<size>0x00000008</size>
-					<description>UART control register</description>
+					<name>T2STA</name>
+					<description>WUT Status</description>
+					<addressOffset>0x2C</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
-							<name>DISABLE</name>
-							<description>Uart Disable</description>
+							<name>PDOK</name>
+							<description> Enable bit synchronized</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>FREEZE</name>
+							<description> Timer value freeze</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>IRQCRY</name>
+							<description> Wakeup status to powerdown</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>ROLL</name>
+							<description> Rollover interrupt flag</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFD</name>
+							<description> T2WUFD interrupt flag</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFC</name>
+							<description> T2WUFC interrupt flag</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFB</name>
+							<description> T2WUFB interrupt flag</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFA</name>
+							<description> T2WUFA interrupt flag</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>T2CLRI</name>
+					<description>WUT Clear interrupt register</description>
+					<addressOffset>0x30</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>ROLL</name>
+							<description> Rollover interrupt clear</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFD</name>
+							<description> T2WUFD interrupt clear</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFC</name>
+							<description> T2WUFC interrupt clear</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFB</name>
+							<description> T2WUFB interrupt clear</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WUFA</name>
+							<description> T2WUFA interrupt clear</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>WUTVAL_LOW</name>
+					<description>WUT Unsynchronized lower 16 bits of WU Timer counter value.</description>
+					<addressOffset>0x34</addressOffset>
+					<size>16</size>
+				</register>		
+
+				<register>
+					<name>WUTVAL_HIGH</name>
+					<description>WUT Unsynchronized upper 16 bits of WU Timer counter value.</description>
+					<addressOffset>0x38</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>T2WUFA0</name>
+					<description>WUT Wakeup field A - LS halfword</description>
+					<addressOffset>0x3C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>T2WUFA1</name>
+					<description>WUT Wakeup field A - MS halfword</description>
+					<addressOffset>0x40</addressOffset>
+					<size>16</size>
+				</register>
+			</registers>
+		</peripheral>
+		<peripheral>
+			<name>ADI_WDT</name>
+			<description>WatchDog Timer</description>
+			<groupName>WDT</groupName>
+			<baseAddress>0x40002580</baseAddress>
+			<size>16</size>
+
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x1c</size>
+				<usage>registers</usage>
+			</addressBlock>
+
+			<interrupt>
+				<name>WDT</name>
+				<description>WDT Interrupt</description>
+				<value>10</value>
+			</interrupt>
+
+			<registers>
+
+				<register>
+					<name>T3LD</name>
+					<description>WDT Load value</description>
+					<addressOffset>0x00</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>T3VAL</name>
+					<description>WDT Current count value</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>
+				</register>
+
+			<register>
+				<name>T3CON</name>
+				<description>WDT Control</description>
+				<addressOffset>0x08</addressOffset>
+				<size>16</size>
+					<fields>
+						<field>
+							<name>MOD</name>
+							<description> Timer mode</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>ENABLE</name>
+							<description> Timer enable</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>PRE</name>
+							<description> Prescaler</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>2</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<name>DIS</name>
+									<description>If Core CLK Divide by 4 otherwise divide by 1</description>
+									<name>DIV1</name>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>EN</name>
+									<description>Divide clock source by 16</description>								
+									<name>DIV16</name>
 									<value>1</value>
 								</enumeratedValue>
-							</enumeratedValues>
+								<enumeratedValue>
+									<description>Divide clock source by 256</description>								
+									<name>DIV256</name>
+									<value>2</value>
+								</enumeratedValue>
+								<enumeratedValue>
+									<description>Divide clock source by 4096</description>								
+									<name>DIV4096</name>
+									<value>3</value>
+								</enumeratedValue>
+							</enumeratedValues>								
+						</field>
+						<field>
+							<name>IRQ</name>
+							<description> Timer interrupt</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>PMD</name>
+							<description> Power Mode Disable</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>T3CLRI</name>
+					<description>WDT Clear interrupt register</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>T3STA</name>
+					<description>WDT Status</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>LOCK</name>
+							<description> Lock status bit</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CON</name>
+							<description> T3CON write sync in progress</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>LD</name>
+							<description> T3LD write sync in progress</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CLRI</name>
+							<description> T3CLRI write sync in progress</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>IRQ</name>
+							<description> WDT Interrupt</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
 						</field>
 					</fields>
 				</register>
 			</registers>
 		</peripheral>
 		
+		<peripheral>
+		<name>ADI_RTC</name>
+		<description>RealTimeClock</description>
+	<groupName>RTC</groupName>
+	<baseAddress>0x40002600</baseAddress>
+	<size>32</size>
+
+	<addressBlock>
+		<offset>0</offset>
+		<size>0x24</size>
+		<usage>registers</usage>
+	</addressBlock>
+
+	<interrupt>
+		<name>RTC</name>
+		<description>Real Time Clock interrupt</description>
+		<value>43</value>
+	</interrupt>
+    <registers>
+
+	<register>
+		<name>RTCCR</name>
+		<description>RTC RTC Control</description>
+		<addressOffset>0x00</addressOffset>
+		<size>16</size>
+            <fields>
+                <field>
+                    <name>WPENDINTEN</name>
+                    <description> Enable WPENDINT-sourced interrupts to the CPU</description>
+                    <bitOffset>15</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WSYNCINTEN</name>
+                    <description> Enable WSYNCINT-sourced interrupts to the CPU</description>
+                    <bitOffset>14</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WPENDERRINTEN</name>
+                    <description> Enable WPENDERRINT-sourced interrupts to the CPU when an RTC register-write pending error occurs</description>
+                    <bitOffset>13</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>ISOINTEN</name>
+                    <description> Enable ISOINT-sourced interrupts to the CPU when isolation of the RTC power domain is activated and subsequently de-activated</description>
+                    <bitOffset>12</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>LCDINTEN</name>
+                    <description> Enable LCDINT-sourced LCD update interrupts to the CPU</description>
+                    <bitOffset>11</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>LCDUPDTIM</name>
+                    <description> LCD update time in seconds beyond a one-minute boundary</description>
+                    <bitOffset>5</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>LCDEN</name>
+                    <description> Enable RTC determination of when an LCD minute display update should occur</description>
+                    <bitOffset>4</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>TRMEN</name>
+                    <description> Enable RTC digital trimming</description>
+                    <bitOffset>3</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>ALMINTEN</name>
+                    <description> Enable ALMINT-sourced alarm interrupts to the CPU</description>
+                    <bitOffset>2</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>ALMEN</name>
+                    <description> Enable the RTC alarm operation</description>
+                    <bitOffset>1</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>CNTEN</name>
+                    <description> Global enable for the RTC</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+        </register>
 		
-  <peripheral>
-			<name>ADI_GPIO1</name>
-			<description>General Purpose Input Output</description>
-			<groupName>GPIO1</groupName>
-			<baseAddress>0x40020040</baseAddress>
+		<register>
+			<name>RTCSR0</name>
+			<description>RTC RTC Status 0</description>
+			<addressOffset>0x04</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>WSYNCTRM</name>
+                    <description> Synchronisation status of posted writes to RTCTRM</description>
+                    <bitOffset>13</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WSYNCALM1</name>
+                    <description> Synchronisation status of posted writes to RTCALM1</description>
+                    <bitOffset>12</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WSYNCALM0</name>
+                    <description> Synchronisation status of posted writes to RTCALM0</description>
+                    <bitOffset>11</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WSYNCCNT1</name>
+                    <description> Synchronisation status of posted writes to RTCCNT1</description>
+                    <bitOffset>10</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WSYNCCNT0</name>
+                    <description> Synchronisation status of posted writes to RTCCNT0</description>
+                    <bitOffset>9</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WSYNCSR0</name>
+                    <description> Synchronisation status of posted clearances to interrupt sources in RTCSR0</description>
+                    <bitOffset>8</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WSYNCCR</name>
+                    <description> Synchronisation status of posted writes to RTCCR</description>
+                    <bitOffset>7</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WPENDINT</name>
+                    <description> Write pending interrupt</description>
+                    <bitOffset>6</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WSYNCINT</name>
+                    <description> Write synchronisation interrupt</description>
+                    <bitOffset>5</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WPENDERRINT</name>
+                    <description> Write pending error interrupt source</description>
+                    <bitOffset>4</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>ISOINT</name>
+                    <description> RTC power-domain isolation interrupt source</description>
+                    <bitOffset>3</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>LCDINT</name>
+                    <description> LCD update interrupt source</description>
+                    <bitOffset>2</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>ALMINT</name>
+                    <description> Alarm interrupt source</description>
+                    <bitOffset>1</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>RTCFAIL</name>
+                    <description> RTC failure interrupt source</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+        </register>
+
+		<register>
+			<name>RTCSR1</name>
+			<description>RTC RTC Status 1</description>
+			<addressOffset>0x08</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>WPENDTRM</name>
+                    <description> Pending status of posted writes to RTCTRM</description>
+                    <bitOffset>13</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WPENDALM1</name>
+                    <description> Pending status of posted writes to RTCALM1</description>
+                    <bitOffset>12</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WPENDALM0</name>
+                    <description> Pending status of posted writes to RTCALM0</description>
+                    <bitOffset>11</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WPENDCNT1</name>
+                    <description> Pending status of posted writes to RTCCNT1</description>
+                    <bitOffset>10</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WPENDCNT0</name>
+                    <description> Pending status of posted writes to RTCCNT0</description>
+                    <bitOffset>9</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WPENDSR0</name>
+                    <description> Pending status of posted clearances of interrupt sources in RTCSR0</description>
+                    <bitOffset>8</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WPENDCR</name>
+                    <description> Pending status of posted writes to RTCCR</description>
+                    <bitOffset>7</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>WERRCODE</name>
+                    <description> Identifier for the source of a write synchronisation error</description>
+                    <bitOffset>3</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+        </register>
+
+		<register>
+			<name>RTCCNT0</name>
+			<description>RTC RTC Count 0</description>
+			<addressOffset>0x0C</addressOffset>
+			<size>16</size>
+		</register>
+
+		<register>
+			<name>RTCCNT1</name>
+			<description>RTC RTC Count 1</description>
+			<addressOffset>0x10</addressOffset>
+			<size>16</size>
+		</register>
+
+		<register>
+			<name>RTCALM0</name>
+			<description>RTC RTC Alarm 0</description>
+			<addressOffset>0x14</addressOffset>
+			<size>16</size>
+		</register>
+
+		<register>
+			<name>RTCALM1</name>
+			<description>RTC RTC Alarm 1</description>
+			<addressOffset>0x18</addressOffset>
+			<size>16</size>
+		</register>
+
+		<register>
+			<name>RTCTRM</name>
+			<description>RTC RTC Trim</description>
+			<addressOffset>0x1C</addressOffset>
+			<size>16</size>
+			<fields>
+                <field>
+                    <name>TRMIVL</name>
+                    <description> Trim interval in units of seconds</description>
+                    <bitOffset>4</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>TRMADD</name>
+                    <description> Trim polarity</description>
+                    <bitOffset>3</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>TRMVAL</name>
+                    <description> Trim value in whole seconds to be added or subtracted from the RTC count at the end of a periodic interval</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+        </register>
+
+		<register>
+			<name>RTCGWY</name>
+			<description>RTC RTC Gateway</description>
+			<addressOffset>0x20</addressOffset>
+			<size>16</size>
+		</register>
+		</registers>
+	</peripheral>
+		<peripheral>
+			<name>ADI_I2C</name>
+			
+			<description>I2C Master/Slave</description>
+			<groupName>I2C</groupName>
+			<baseAddress>0x40003000</baseAddress>
+			<size>32</size>
+
 			<addressBlock>
 				<offset>0</offset>
-				<size>0x28</size>
+				<size>0x58</size>
 				<usage>registers</usage>
 			</addressBlock>
+
+			<interrupt>
+				<name>I2CS</name>
+				<description>I2C 0 slave interrupt</description>
+				<value>17</value>
+			</interrupt>
+			<interrupt>
+				<name>I2CM</name>
+				<description>I2C 0 master interrupt</description>
+				<value>18</value>
+			</interrupt>			
 			<registers>
+
 				<register>
-					<name>GP1CON</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<description>GPIO Port 1 configuration</description>
+					<name>I2CMCON</name>
+					<description>I2C Master control</description>
+					<addressOffset>0x00</addressOffset>
+					<size>16</size>
 					<fields>
-            <field>
-							<name>PIN_15_CFG</name>
-							<description>Configuration bis 1.15</description>
-							<bitOffset>30</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 18</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 15</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+						<field>
+							<name>PRESTOP</name>
+							<description> Prestop Bus-Clear</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
 						</field>
 						<field>
-							<name>PIN_14_CFG</name>
-							<description>Configuration bis 1.14</description>
-							<bitOffset>28</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 17</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 14</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<name>BUS</name>
+							<description> Bus-Clear Enable</description>
+							<bitOffset>12</bitOffset>
+							<bitWidth>1</bitWidth>
 						</field>
 						<field>
-							<name>PIN_13_CFG</name>
-							<description>Configuration bis 1.13</description>
-							<bitOffset>26</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 16</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 13</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<name>MTXDMA</name>
+							<description> Enable master Tx DMA request</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
 						</field>
 						<field>
-							<name>PIN_12_CFG</name>
-							<description>Configuration bis 1.12</description>
-							<bitOffset>24</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 15</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 12</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<name>MRXDMA</name>
+							<description> Enable master Rx DMA request</description>
+							<bitOffset>10</bitOffset>
+							<bitWidth>1</bitWidth>
 						</field>
 						<field>
-							<name>PIN_11_CFG</name>
-							<description>Configuration bis 1.11</description>
-							<bitOffset>22</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 14</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 11</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<name>MXMITDEC</name>
+							<description> Decrement master TX FIFO status when a byte has been transmitted</description>
+							<bitOffset>9</bitOffset>
+							<bitWidth>1</bitWidth>
 						</field>
 						<field>
-							<name>PIN_10_CFG</name>
-							<description>Configuration bis 1.10</description>
-							<bitOffset>20</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 13</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 10</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<name>IENCMP</name>
+							<description> Transaction completed (or stop detected) interrupt enable</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
 						</field>
 						<field>
-							<name>PIN_9_CFG</name>
-							<description>Configuration bis 1.9</description>
-							<bitOffset>18</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 12</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 9</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<name>IENACK</name>
+							<description> ACK not received interrupt enable</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
 						</field>
-				   	<field>
-							<name>PIN_8_CFG</name>
-							<description>Configuration bis 1.8</description>
-							<bitOffset>16</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 11</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 8</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>	
 						<field>
-							<name>PIN_7_CFG</name>
-							<description>Configuration bis 1.7</description>
+							<name>IENALOST</name>
+							<description> Arbitration lost interrupt enable</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>IENMTX</name>
+							<description> Transmit request interrupt enable.</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>IENMRX</name>
+							<description> Receive request interrupt enable</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>STRETCH</name>
+							<description> Stretch SCL enable</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>LOOPBACK</name>
+							<description> Internal loopback enable</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>COMPLETE</name>
+							<description> Start back-off disable</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MASEN</name>
+							<description> Master enable</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CMSTA</name>
+					<description>I2C Master status</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>SCL</name>
+							<description> State of SCL Line</description>
+							<bitOffset>14</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>SDA</name>
+							<description> State of SDA Line</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MTXUFLOW</name>
+							<description> Master Transmit Underflow</description>
+							<bitOffset>12</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MSTOP</name>
+							<description> STOP driven by this I2C Master</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>LINEBUSY</name>
+							<description> Line is busy</description>
+							<bitOffset>10</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MRXOF</name>
+							<description> Master Receive FIFO overflow</description>
+							<bitOffset>9</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TCOMP</name>
+							<description> Transaction complete or stop detected</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>NACKDATA</name>
+							<description> ACK not received in response to data write</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MBUSY</name>
+							<description> Master busy</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>ALOST</name>
+							<description> Arbitration lost</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>NACKADDR</name>
+							<description> ACK not received in response to an address</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MRXREQ</name>
+							<description> Master Receive request</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MTXREQ</name>
+							<description> Master Transmit request</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MTXFSTA</name>
+							<description> Master Transmit FIFO status</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CMRX</name>
+					<description>I2C Master receive data</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>I2CMRX</name>
+							<description> Master receive register</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CMTX</name>
+					<description>I2C Master transmit data</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>I2CMTX</name>
+							<description> Master transmit register</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CMRXCNT</name>
+					<description>I2C Master receive data count</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>EXTEND</name>
+							<description> Extended read</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>COUNT</name>
+							<description> Receive count</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CMCRXCNT</name>
+					<description>I2C Master current receive data count</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>COUNT</name>
+							<description> Current receive count</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CADR1</name>
+					<description>I2C 1st master address byte</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>ADR1</name>
+							<description> Address byte 1</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CADR2</name>
+					<description>I2C 2nd master address byte</description>
+					<addressOffset>0x1C</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>ADR2</name>
+							<description> Address byte 2</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+				<register>
+					<name>I2CBYT</name>
+					<description>I2C Start byte</description>
+					<addressOffset>0x20</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>SBYTE</name>
+							<description> Start byte</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CDIV</name>
+					<description>I2C Serial clock period divisor</description>
+					<addressOffset>0x24</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>HIGH</name>
+							<description> Serial clock high time</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>LOW</name>
+							<description> Serial clock low time</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CSCON</name>
+					<description>I2C Slave control</description>
+					<addressOffset>0x28</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>STXDMA</name>
+							<description> Enable slave Tx DMA request</description>
+							<bitOffset>14</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>SRXDMA</name>
+							<description> Enable slave Rx DMA request</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>IENREPST</name>
+							<description> Repeated start interrupt enable</description>
+							<bitOffset>12</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>SXMITDEC</name>
+							<description> Decrement Slave Tx FIFO status when a byte has been transmitted</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>IENSTX</name>
+							<description> Slave Transmit request interrupt enable</description>
+							<bitOffset>10</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>IENSRX</name>
+							<description> Slave Receive request interrupt enable</description>
+							<bitOffset>9</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>IENSTOP</name>
+							<description> Stop condition detected interrupt enable</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>NACK</name>
+							<description> NACK next communication</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>STRETCHSCL</name>
+							<description> Stretch SCL enable</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>EARLYTXR</name>
+							<description> Early transmit request mode</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>GCSBCLR</name>
+							<description> General call status bit clear</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>HGCEN</name>
+							<description> Hardware general call enable</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>GCEN</name>
+							<description> General call enable</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>ADR10EN</name>
+							<description> Enabled 10-bit addressing</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>SLVEN</name>
+							<description> Slave enable</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CSSTA</name>
+					<description>I2C Slave I2C Status/Error/IRQ</description>
+					<addressOffset>0x2C</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>START</name>
+							<description> Start and matching address</description>
+							<bitOffset>14</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>REPSTART</name>
+							<description> Repeated start and matching address</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>IDMAT</name>
+							<description> Device ID matched</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>STOP</name>
+							<description> Stop after start and matching address</description>
+							<bitOffset>10</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>GCID</name>
+							<description> General ID</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>GCINT</name>
+							<description> General call interrupt</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>SBUSY</name>
+							<description> Slave busy</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>NOACK</name>
+							<description> Ack not generated by the slave</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>SRXOF</name>
+							<description> Slave Receive FIFO overflow</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>SRXREQ</name>
+							<description> Slave Receive request</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>STXREQ</name>
+							<description> Slave Transmit request</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>STXUR</name>
+							<description> Slave Transmit FIFO underflow</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>STXFSEREQ</name>
+							<description> Slave Tx FIFO Status or early request</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CSRX</name>
+					<description>I2C Slave receive</description>
+					<addressOffset>0x30</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>I2CSRX</name>
+							<description> Slave receive register</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CSTX</name>
+					<description>I2C Slave transmit</description>
+					<addressOffset>0x34</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>I2CSTX</name>
+							<description> Slave transmit register</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CALT</name>
+					<description>I2C Hardware general call ID</description>
+					<addressOffset>0x38</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>ALT</name>
+							<description> Slave Alt</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CID0</name>
+					<description>I2C 1st slave address device ID</description>
+					<addressOffset>0x3C</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>ID0</name>
+							<description> Slave device ID 0</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CID1</name>
+					<description>I2C 2nd slave address device ID</description>
+					<addressOffset>0x40</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>ID1</name>
+							<description> Slave device ID 1</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CID2</name>
+					<description>I2C 3rd slave address device ID</description>
+					<addressOffset>0x44</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>ID2</name>
+							<description> Slave device ID 2</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CID3</name>
+					<description>I2C 4th slave address device ID</description>
+					<addressOffset>0x48</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>ID3</name>
+							<description> Slave device ID 3</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+			<name>I2CFSTA</name>
+			<description>I2C Master and slave FIFO status</description>
+			<addressOffset>0x4C</addressOffset>
+			<size>16</size>
+            <fields>
+                <field>
+                    <name>MFLUSH</name>
+                    <description> Flush the master transmit FIFO</description>
+                    <bitOffset>9</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>SFLUSH</name>
+                    <description> Flush the slave transmit FIFO</description>
+                    <bitOffset>8</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>MRXFSTA</name>
+                    <description> Master receive FIFO status</description>
+                    <bitOffset>6</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>MTXFSTA</name>
+                    <description> Master transmit FIFO status</description>
+                    <bitOffset>4</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>SRXFSTA</name>
+                    <description> Slave receive FIFO status</description>
+                    <bitOffset>2</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+                <field>
+                    <name>STXFSTA</name>
+                    <description> Slave transmit FIFO status</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+            </fields>
+        </register>
+
+				<register>
+					<name>I2CSHCON</name>
+					<description>I2C Shared control</description>
+					<addressOffset>0x50</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>RESET</name>
+							<description> Reset START STOP detect circuit</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>I2CTCTL</name>
+					<description>I2C Timing Control Register</description>
+					<addressOffset>0x54</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>FILTEROFF</name>
+							<description> Input Filter Control</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>THDATIN</name>
+							<description> Data In Hold Start</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+			</registers>
+		</peripheral>
+
+		<peripheral>
+			<name>ADI_SPI0</name>
+			
+			<description>SPI0 Maste/Slave</description>
+			<groupName>SPI0</groupName>
+			<baseAddress>0x40004000</baseAddress>
+			<size>32</size>
+
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x1c</size>
+				<usage>registers</usage>
+			</addressBlock>
+
+			<interrupt>
+				<name>SPI0</name>
+				<description>SPI 0 interrupt</description>
+				<value>15</value>
+			</interrupt>
+
+			<registers>	
+				<register>
+					<name>SPISTA</name>
+					<description>SPI0 Status</description>
+					<addressOffset>0x00</addressOffset>
+					<fields>
+						<field>
+							<name>CSRSG</name>
+							<description> Detected a rising edge on CS, in CONT mode</description>
+							<bitOffset>14</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CSFLG</name>
+							<description> Detected a falling edge on CS, in CONT mode</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CSERR</name>
+							<description> Detected a CS error condition</description>
+							<bitOffset>12</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RXS</name>
+							<description> SPI Rx FIFO excess bytes present</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RXFSTA</name>
+							<description> SPI Rx FIFO status</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>3</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>RX FIFO Empty</description>							
+								<name>EMPTY</name>
+								<value>0</value>
+							</enumeratedValue>								
+							<enumeratedValue>
+								<description>1 Valid Byte in FIFO</description>
+								<name>FIFO1</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>2 Valid Bytes in FIFO</description>							
+								<name>FIFO2</name>
+								<value>2</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>3 Valid Bytes in FIFO</description>							
+								<name>FIFO3</name>
+								<value>3</value>
+							</enumeratedValue>							
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>RXOF</name>
+							<description>SPI Rx FIFO overflow</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RX</name>
+							<description>SPI Rx IRQ</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TX</name>
+							<description>SPI Tx IRQ</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TXUR</name>
+							<description> SPI Tx FIFO underflow</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TXFSTA</name>
+							<description> SPI Tx FIFO status</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>3</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>TX FIFO Empty</description>							
+								<name>EMPTY</name>
+								<value>0</value>
+							</enumeratedValue>								
+							<enumeratedValue>
+								<description>1 Valid Byte in FIFO</description>
+								<name>FIFO1</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>2 Valid Bytes in FIFO</description>							
+								<name>FIFO2</name>
+								<value>2</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>3 Valid Bytes in FIFO</description>							
+								<name>FIFO3</name>
+								<value>3</value>
+							</enumeratedValue>							
+						</enumeratedValues>	
+						</field>
+						<field>
+							<name>IRQ</name>
+							<description> SPI Interrupt status</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPIRX</name>
+					<description>SPI0 Receive</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>DMA</name>
+							<description> 8-bit receive buffer</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+						<field>
+							<name>DATA</name>
+							<description> 8-bit receive buffer</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPITX</name>
+					<description>SPI0 Transmit</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>DMA</name>
+							<description> 8-bit transmit buffer</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+						<field>
+							<name>DATA</name>
+							<description> 8-bit transmit buffer</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPIDIV</name>
+					<description>SPI0 Baud rate selection</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>CSIRQ</name>
+							<description> Enable interrupt on every CS edge in CONT mode</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MD</name>
+							<description> Reset Mode for CSERR</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>HFM</name>
+							<description> High Frequency Mode</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>DIV</name>
+							<description> SPI clock divider</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>6</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPICON</name>
+					<description>SPI0 SPI configuration</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>MOD</name>
+							<description> SPI IRQ mode bits</description>
 							<bitOffset>14</bitOffset>
 							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 10</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 7</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
-							<name>PIN_6_CFG</name>
-							<description>Configuration bis 1.6</description>
+							<name>TFLUSH</name>
+							<description> SPI Tx FIFO Flush enable</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RFLUSH</name>
+							<description> SPI Rx FIFO Flush enable</description>
 							<bitOffset>12</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 9</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 6</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<bitWidth>1</bitWidth>
 						</field>
 						<field>
-							<name>PIN_5_CFG</name>
-							<description>Configuration bis 1.5</description>
+							<name>CON</name>
+							<description> Continuous transfer enable</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>LOOPBACK</name>
+							<description> Loopback enable</description>
 							<bitOffset>10</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 8</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 5</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<bitWidth>1</bitWidth>
 						</field>
 						<field>
-							<name>PIN_4_CFG</name>
-							<description>Configuration bis 1.4</description>
+							<name>OEN</name>
+							<description> Slave MISO output enable</description>
+							<bitOffset>9</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RXOF</name>
+							<description> SPIRX overflow overwrite enable</description>
 							<bitOffset>8</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 7</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 4</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<bitWidth>1</bitWidth>
 						</field>
 						<field>
-							<name>PIN_3_CFG</name>
-							<description>Configuration bis 1.3</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 6</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 3</name>
-									<value>2</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PIN_2_CFG</name>
-							<description>Configuration bis 1.2</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 5</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 2</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI serial data in</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PIN_1_CFG</name>
-							<description>Configuration bis 1.1</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 4</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 1</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI serial data out</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PIN_0_CFG</name>
-							<description>Configuration b s 1.0</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>LCD Driver Segment 3</name>
-									<value>1</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI Data 0</name>
-									<value>2</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>PDI serial clock</name>
-									<value>3</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>GP1OEN</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Pin output drive enable</description>
-				</register>
-				<register>
-					<name>GP1PE</name>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 output pull-up / pull-down enable.</description>
-				</register>
-				<register>
-					<name>GP1IEN</name>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 input path enable. Each bit is set to enable and cleared to disable the input path for the GPIO pin</description>
-				</register>
-				<register>
-					<name>GP1IN</name>
-					<addressOffset>0x00000010</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 registered data input.</description>
-				</register>
-				<register>
-					<name>GP1OUT</name>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 data out.</description>
-				</register>
-				<register>
-					<name>GP1SET</name>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 data out set</description>
-				</register>
-				<register>
-					<name>GP1CLR</name>
-					<addressOffset>0x0000001c</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 data out clear.</description>
-				</register>
-				<register>
-					<name>GP1TGL</name>
-					<addressOffset>0x00000020</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 pin toggle.</description>
-				</register>
-			  <register>
-					<name>GP1POL</name>
-					<addressOffset>0x00000024</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 interrupt polarity register.</description>
-				 </register>
-			  <register>
-					<name>GP1IENA</name>
-					<addressOffset>0x00000028</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 Interrupt A enable register.</description>
-				</register>
-				<register>
-					<name>GP1IENB</name>
-					<addressOffset>0x0000002C</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 Interrupt B enable register.</description>
-				</register>
-				<register>
-					<name>GP1INT</name>
-					<addressOffset>0x00000030</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 Interrupt status register.</description>
-				</register>
-				<register>
-					<name>GP1DS</name>
-					<addressOffset>0x00000034</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 1 drive strength register.</description>
-				</register>
-			</registers>
-		</peripheral>
-  <peripheral>
-			<name>ADI_GPIO2</name>
-			<description>General Purpose Input Output</description>
-			<groupName>GPIO2</groupName>
-			<baseAddress>0x40006060</baseAddress>
-			<addressBlock>
-				<offset>0</offset>
-				<size>0x28</size>
-				<usage>registers</usage>
-			</addressBlock>
-			<registers>
-				<register>
-					<name>GP2CON</name>
-					<addressOffset>0x00000000</addressOffset>
-					<size>0x00000010</size>
-					<description>GPIO Port 2 configuration</description>
-					<fields>
-						<field>
-							<name>CON4</name>
-							<description>Configuration bits for P2.4</description>
-							<bitOffset>8</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SWDATA</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CON3</name>
-							<description>Configuration bits for P2.3</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SWCLK</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CON2</name>
-							<description>Configuration bits for P2.2</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CON1</name>
-							<description>Configuration bits for P2.1</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>I2CSDA</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CON0</name>
-							<description>Configuration bits for P2.0</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>2</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>GPIO</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>I2CSCL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>GP2OEN</name>
-					<addressOffset>0x00000004</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 2 output enable</description>
-					<fields>
-						<field>
-							<name>OEN7</name>
-							<description>Direction for port pin</description>
+							<name>ZEN</name>
+							<description> Transmit zeros enable</description>
 							<bitOffset>7</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>IN</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>OUT</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
-							<name>OEN6</name>
-							<description>Direction for port pin</description>
+							<name>TIM</name>
+							<description> SPI transfer and interrupt mode</description>
 							<bitOffset>6</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>IN</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>OUT</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
-							<name>OEN5</name>
-							<description>Direction for port pin</description>
+							<name>LSB</name>
+							<description> LSB first transfer enable</description>
 							<bitOffset>5</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>IN</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>OUT</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
-							<name>OEN4</name>
-							<description>Direction for port pin</description>
+							<name>WOM</name>
+							<description> SPI Wired Or mode</description>
 							<bitOffset>4</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>IN</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>OUT</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
-							<name>OEN3</name>
-							<description>Direction for port pin</description>
+							<name>CPOL</name>
+							<description> Serial Clock Polarity</description>
 							<bitOffset>3</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>IN</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>OUT</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
-							<name>OEN2</name>
-							<description>Direction for port pin</description>
+							<name>CPHA</name>
+							<description> Serial clock phase mode</description>
 							<bitOffset>2</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>IN</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>OUT</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
-							<name>OEN1</name>
-							<description>Direction for port pin</description>
+							<name>MASEN</name>
+							<description> Master mode enable</description>
 							<bitOffset>1</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>IN</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>OUT</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 						<field>
-							<name>OEN0</name>
-							<description>Direction for port pin</description>
+							<name>ENABLE</name>
+							<description> SPI enable</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>IN</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>OUT</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
 						</field>
 					</fields>
 				</register>
+
 				<register>
-					<name>GP2PUL</name>
-					<addressOffset>0x00000008</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 2 output pull up enable.</description>
+					<name>SPIDMA</name>
+					<description>SPI0 SPI DMA enable</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
-							<name>PUL7</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL6</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL5</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL4</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL3</name>
-							<description>Pull Up Enable for port pin</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>PUL2</name>
-							<description>Pull Up Enable for port pin</description>
+							<name>IENRXDMA</name>
+							<description> Enable receive DMA request</description>
 							<bitOffset>2</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
 						</field>
 						<field>
-							<name>PUL1</name>
-							<description>Pull Up Enable for port pin</description>
+							<name>IENTXDMA</name>
+							<description> Enable transmit DMA request</description>
 							<bitOffset>1</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
 						</field>
 						<field>
-							<name>PUL0</name>
-							<description>Pull Up Enable for port pin</description>
+							<name>ENABLE</name>
+							<description> Enable DMA for data transfer</description>
 							<bitOffset>0</bitOffset>
 							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
 						</field>
 					</fields>
 				</register>
+
 				<register>
-					<name>GP2OCE</name>
-					<addressOffset>0x0000000C</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 2 tri state</description>
+					<name>SPICNT</name>
+					<description>SPI0 Transfer byte count</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
 					<fields>
 						<field>
-							<name>OCE7</name>
-							<description>open circuit Enable for port pin</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OCE6</name>
-							<description>open circuit Enable for port pin</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OCE5</name>
-							<description>open circuit Enable for port pin</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OCE4</name>
-							<description>open circuit Enable for port pin</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OCE3</name>
-							<description>open circuit Enable for port pin</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OCE2</name>
-							<description>open circuit Enable for port pin</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OCE1</name>
-							<description>open circuit Enable for port pin</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OCE0</name>
-							<description>open circuit Enable for port pin</description>
+							<name>COUNT</name>
+							<description> Transfer byte count</description>
 							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>DIS</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>EN</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>GP2IN</name>
-					<addressOffset>0x00000014</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 2 data input.</description>
-					<fields>
-						<field>
-							<name>IN7</name>
-							<description>Input for port pin</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IN6</name>
-							<description>Input for port pin</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IN5</name>
-							<description>Input for port pin</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IN4</name>
-							<description>Input for port pin</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IN3</name>
-							<description>Input for port pin</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IN2</name>
-							<description>Input for port pin</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IN1</name>
-							<description>Input for port pin</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>IN0</name>
-							<description>Input for port pin</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>GP2OUT</name>
-					<addressOffset>0x00000018</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 2 data out.</description>
-					<fields>
-						<field>
-							<name>OUT7</name>
-							<description>Output for port pin</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OUT6</name>
-							<description>Output for port pin</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OUT5</name>
-							<description>Output for port pin</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OUT4</name>
-							<description>Output for port pin</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OUT3</name>
-							<description>Output for port pin</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OUT2</name>
-							<description>Output for port pin</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OUT1</name>
-							<description>Output for port pin</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>OUT0</name>
-							<description>Output for port pin</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>LOW</name>
-									<value>0</value>
-								</enumeratedValue>
-								<enumeratedValue>
-									<name>HIGH</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>GP2SET</name>
-					<addressOffset>0x0000001C</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 2 data out set</description>
-					<fields>
-						<field>
-							<name>SET7</name>
-							<description>Set Output High for port pin</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SET6</name>
-							<description>Set Output High for port pin</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SET5</name>
-							<description>Set Output High for port pin</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SET4</name>
-							<description>Set Output High for port pin</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SET3</name>
-							<description>Set Output High for port pin</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SET2</name>
-							<description>Set Output High for port pin</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SET1</name>
-							<description>Set Output High for port pin</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>SET0</name>
-							<description>Set Output High for port pin</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>SET</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>GP2CLR</name>
-					<addressOffset>0x00000020</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 2 data out clear.</description>
-					<fields>
-						<field>
-							<name>CLR7</name>
-							<description>Set Output Low for port pin</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CLR6</name>
-							<description>Set Output Low for port pin</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CLR5</name>
-							<description>Set Output Low for port pin</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CLR4</name>
-							<description>Set Output Low for port pin</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CLR3</name>
-							<description>Set Output Low for port pin</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CLR2</name>
-							<description>Set Output Low for port pin</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CLR1</name>
-							<description>Set Output Low for port pin</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>CLR0</name>
-							<description>Set Output Low for port pin</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>CLR</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-					</fields>
-				</register>
-				<register>
-					<name>GP2TGL</name>
-					<addressOffset>0x00000024</addressOffset>
-					<size>0x00000008</size>
-					<description>GPIO Port 2 pin toggle.</description>
-          <fields>
-						<field>
-							<name>TGL7</name>
-							<description>Toggle Output for port pin</description>
-							<bitOffset>7</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TGL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TGL6</name>
-							<description>Toggle Output for port pin</description>
-							<bitOffset>6</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TGL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TGL5</name>
-							<description>Toggle Output for port pin</description>
-							<bitOffset>5</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TGL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TGL4</name>
-							<description>Toggle Output for port pin</description>
-							<bitOffset>4</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TGL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TGL3</name>
-							<description>Toggle Output for port pin</description>
-							<bitOffset>3</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TGL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TGL2</name>
-							<description>Toggle Output for port pin</description>
-							<bitOffset>2</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TGL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TGL1</name>
-							<description>Toggle Output for port pin</description>
-							<bitOffset>1</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TGL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
-						</field>
-						<field>
-							<name>TGL0</name>
-							<description>Toggle Output for port pin</description>
-							<bitOffset>0</bitOffset>
-							<bitWidth>1</bitWidth>
-							<enumeratedValues>
-								<enumeratedValue>
-									<name>TGL</name>
-									<value>1</value>
-								</enumeratedValue>
-							</enumeratedValues>
+							<bitWidth>8</bitWidth>
 						</field>
 					</fields>
 				</register>
 			</registers>
 		</peripheral>
 		
+		<peripheral>
+			<name>ADI_SPI1</name>
+			
+			<description>SPI1 Master/Slave</description>
+			<groupName>SPI1</groupName>
+			<baseAddress>0x40004400</baseAddress>
+			<size>32</size>
 
-</peripherals>
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x1c</size>
+				<usage>registers</usage>
+			</addressBlock>
+
+			<interrupt>
+				<name>SPI1</name>
+				<description>interrupt</description>
+				<value>42</value>
+			</interrupt>
+			<registers>	
+				<register>
+					<name>SPISTA</name>
+					<description>SPI1 Status</description>
+					<addressOffset>0x00</addressOffset>
+					<fields>
+						<field>
+							<name>CSRSG</name>
+							<description> Detected a rising edge on CS, in CONT mode</description>
+							<bitOffset>14</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CSFLG</name>
+							<description> Detected a falling edge on CS, in CONT mode</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CSERR</name>
+							<description> Detected a CS error condition</description>
+							<bitOffset>12</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RXS</name>
+							<description> SPI Rx FIFO excess bytes present</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RXFSTA</name>
+							<description> SPI Rx FIFO status</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>3</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>RX FIFO Empty</description>							
+								<name>EMPTY</name>
+								<value>0</value>
+							</enumeratedValue>								
+							<enumeratedValue>
+								<description>1 Valid Byte in FIFO</description>
+								<name>FIFO1</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>2 Valid Bytes in FIFO</description>							
+								<name>FIFO2</name>
+								<value>2</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>3 Valid Bytes in FIFO</description>							
+								<name>FIFO3</name>
+								<value>3</value>
+							</enumeratedValue>							
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>RXOF</name>
+							<description>SPI Rx FIFO overflow</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RX</name>
+							<description>SPI Rx IRQ</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TX</name>
+							<description>SPI Tx IRQ</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TXUR</name>
+							<description> SPI Tx FIFO underflow</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TXFSTA</name>
+							<description> SPI Tx FIFO status</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>3</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>TX FIFO Empty</description>							
+								<name>EMPTY</name>
+								<value>0</value>
+							</enumeratedValue>								
+							<enumeratedValue>
+								<description>1 Valid Byte in FIFO</description>
+								<name>FIFO1</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>2 Valid Bytes in FIFO</description>							
+								<name>FIFO2</name>
+								<value>2</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>3 Valid Bytes in FIFO</description>							
+								<name>FIFO3</name>
+								<value>3</value>
+							</enumeratedValue>							
+						</enumeratedValues>	
+						</field>
+						<field>
+							<name>IRQ</name>
+							<description> SPI Interrupt status</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPIRX</name>
+					<description>SPI1 Receive</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>DMA</name>
+							<description> 8-bit receive buffer</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+						<field>
+							<name>DATA</name>
+							<description> 8-bit receive buffer</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPITX</name>
+					<description>SPI1 Transmit</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>DMA</name>
+							<description> 8-bit transmit buffer</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+						<field>
+							<name>DATA</name>
+							<description> 8-bit transmit buffer</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPIDIV</name>
+					<description>SPI1 Baud rate selection</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>CSIRQ</name>
+							<description> Enable interrupt on every CS edge in CONT mode</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MD</name>
+							<description> Reset Mode for CSERR</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>HFM</name>
+							<description> High Frequency Mode</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>DIV</name>
+							<description> SPI clock divider</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>6</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPICON</name>
+					<description>SPI1 SPI configuration</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>MOD</name>
+							<description> SPI IRQ mode bits</description>
+							<bitOffset>14</bitOffset>
+							<bitWidth>2</bitWidth>
+						</field>
+						<field>
+							<name>TFLUSH</name>
+							<description> SPI Tx FIFO Flush enable</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RFLUSH</name>
+							<description> SPI Rx FIFO Flush enable</description>
+							<bitOffset>12</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CON</name>
+							<description> Continuous transfer enable</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>LOOPBACK</name>
+							<description> Loopback enable</description>
+							<bitOffset>10</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>OEN</name>
+							<description> Slave MISO output enable</description>
+							<bitOffset>9</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RXOF</name>
+							<description> SPIRX overflow overwrite enable</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>ZEN</name>
+							<description> Transmit zeros enable</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TIM</name>
+							<description> SPI transfer and interrupt mode</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>LSB</name>
+							<description> LSB first transfer enable</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WOM</name>
+							<description> SPI Wired Or mode</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CPOL</name>
+							<description> Serial Clock Polarity</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CPHA</name>
+							<description> Serial clock phase mode</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MASEN</name>
+							<description> Master mode enable</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>ENABLE</name>
+							<description> SPI enable</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPIDMA</name>
+					<description>SPI1 SPI DMA enable</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>IENRXDMA</name>
+							<description> Enable receive DMA request</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>IENTXDMA</name>
+							<description> Enable transmit DMA request</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>ENABLE</name>
+							<description> Enable DMA for data transfer</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPICNT</name>
+					<description>SPI1 Transfer byte count</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>COUNT</name>
+							<description> Transfer byte count</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+					</fields>
+				</register>
+			</registers>
+
+	</peripheral>
+		
+		<peripheral>
+			<name>ADI_UART</name>
+			
+			<description>Uart</description>
+			<groupName>UART</groupName>
+			<baseAddress>0x40005000</baseAddress>
+			<size>32</size>
+
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x34</size>
+				<usage>registers</usage>
+			</addressBlock>
+
+			<interrupt>
+				<name>UART</name>
+				<description>interrupt</description>
+				<value>14</value>
+			</interrupt>
+			<registers>
+
+			<register>
+				<name>COMRX</name>
+				<description>UART Receive Buffer Register</description>
+				<addressOffset>0x00</addressOffset>
+                <fields>
+                    <field>
+                        <name>RBR</name>
+                        <description> Receive Buffer Register</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                </fields>
+            </register>
+<!--
+			<register>
+				<name>COMTX</name>
+				<description>UART Transmit Holding Register</description>
+				<addressOffset>0x00</addressOffset>
+                <fields>
+                    <field>
+                        <name>THR</name>
+                        <description> Transmit Holding Register</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                </fields>
+            </register>
+-->
+			<register>
+				<name>COMIEN</name>
+				<description>UART Interrupt Enable</description>
+				<addressOffset>0x04</addressOffset>
+				<size>16</size>
+				<fields>
+					<field>
+						<name>EDMAR</name>
+						<description> DMA requests in transmit mode</description>
+						<bitOffset>5</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>EDMAT</name>
+						<description> DMA requests in receive mode</description>
+						<bitOffset>4</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>EDSSI</name>
+						<description> Modem status interrupt</description>
+						<bitOffset>3</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>ELSI</name>
+						<description> Rx status interrupt</description>
+						<bitOffset>2</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>ETBEI</name>
+						<description> Transmit buffer empty interrupt</description>
+						<bitOffset>1</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>ERBFI</name>
+						<description> Receive buffer full interrupt</description>
+						<bitOffset>0</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+				</fields>
+			</register>
+
+			<register>
+				<name>COMIIR</name>
+				<description>UART Interrupt ID</description>
+				<addressOffset>0x08</addressOffset>
+				<size>16</size>
+				<fields>
+					<field>
+						<name>STA</name>
+						<description> Interrupt status</description>
+						<bitOffset>1</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>NIRQ</name>
+						<description> Interrupt flag</description>
+						<bitOffset>0</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+				</fields>
+			</register>
+
+			<register>
+				<name>COMLCR</name>
+				<description>UART Line Control</description>
+				<addressOffset>0x0C</addressOffset>
+				<size>16</size>
+				<fields>
+					<field>
+						<name>BRK</name>
+						<description> Set Break</description>
+						<bitOffset>6</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>SP</name>
+						<description> Stick Parity</description>
+						<bitOffset>5</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>EPS</name>
+						<description> Parity Select</description>
+						<bitOffset>4</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>PEN</name>
+						<description> Parity Enable</description>
+						<bitOffset>3</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>STOP</name>
+						<description> Stop Bit</description>
+						<bitOffset>2</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>WLS</name>
+						<description> Word Length Select</description>
+						<bitOffset>0</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+				</fields>
+			</register>
+
+			<register>
+				<name>COMMCR</name>
+				<description>UART Modem Control</description>
+				<addressOffset>0x10</addressOffset>
+				<size>16</size>
+				<fields>
+					<field>
+						<name>LOOPBACK</name>
+						<description> Loopback mode</description>
+						<bitOffset>4</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>OUT2</name>
+						<description> Output 2</description>
+						<bitOffset>3</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>OUT1</name>
+						<description> Output 1</description>
+						<bitOffset>2</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>RTS</name>
+						<description> Request to send</description>
+						<bitOffset>1</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>DTR</name>
+						<description> Data Terminal Ready</description>
+						<bitOffset>0</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+				</fields>
+			</register>
+
+			<register>
+				<name>COMLSR</name>
+				<description>UART Line Status</description>
+				<addressOffset>0x14</addressOffset>
+				<size>16</size>
+				<fields>
+					<field>
+						<name>TEMT</name>
+						<description> COMTX and Shift Register Empty Status</description>
+						<bitOffset>6</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>THRE</name>
+						<description> COMTX Empty</description>
+						<bitOffset>5</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>BI</name>
+						<description> Break Indicator</description>
+						<bitOffset>4</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>FE</name>
+						<description> Framing Error</description>
+						<bitOffset>3</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>PE</name>
+						<description> Parity Error</description>
+						<bitOffset>2</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>OE</name>
+						<description> Overrun Error</description>
+						<bitOffset>1</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>DR</name>
+						<description> Data Ready</description>
+						<bitOffset>0</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+				</fields>
+			</register>
+
+			<register>
+				<name>COMMSR</name>
+				<description>UART Modem Status</description>
+				<addressOffset>0x18</addressOffset>
+				<size>16</size>
+				<fields>
+					<field>
+						<name>DCD</name>
+						<description> Data Carrier Detect</description>
+						<bitOffset>7</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>RI</name>
+						<description> Ring Indicator</description>
+						<bitOffset>6</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>DSR</name>
+						<description> Data Set Ready</description>
+						<bitOffset>5</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>CTS</name>
+						<description> Clear To Send</description>
+						<bitOffset>4</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>DDCD</name>
+						<description> Delta DCD</description>
+						<bitOffset>3</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>TERI</name>
+						<description> Trailing Edge RI</description>
+						<bitOffset>2</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>DDSR</name>
+						<description> Delta DSR</description>
+						<bitOffset>1</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+					<field>
+						<name>DCTS</name>
+						<description> Delta CTS</description>
+						<bitOffset>0</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+				</fields>
+			</register>
+
+			<register>
+				<name>COMSCR</name>
+				<description>UART Scratch buffer</description>
+				<addressOffset>0x1C</addressOffset>
+				<size>16</size>
+				<fields>
+					<field>
+						<name>SCR</name>
+						<description> Scratch</description>
+						<bitOffset>0</bitOffset>
+						<bitWidth>1</bitWidth>
+					</field>
+				</fields>
+			</register>
+			<register>
+				<name>COMFBR</name>
+				<description>UART Fractional Baud Rate</description>
+				<addressOffset>0x24</addressOffset>
+				<size>16</size>
+                <fields>
+                    <field>
+                        <name>FBEN</name>
+                        <description> Fractional baud rate generator enable</description>
+                        <bitOffset>15</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>DIVM</name>
+                        <description> Fractional baud rate M divide bits 1 to 3</description>
+                        <bitOffset>11</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>DIVN</name>
+                        <description> Fractional baud rate N divide bits 0 to 2047.</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+                     </field>
+                </fields>
+            </register>
+
+			<register>
+				<name>COMDIV</name>
+				<description>UART Baudrate divider</description>
+				<addressOffset>0x28</addressOffset>
+				<size>16</size>
+			</register>
+		</registers>
+	</peripheral>
+
+	<peripheral>
+		<name>ADI_I2S</name>
+		
+		<description>I2S Master/Slave</description>
+		<groupName>I2S</groupName>
+		<baseAddress>0x40005800</baseAddress>
+		<size>32</size>
+
+		<addressBlock>
+			<offset>0</offset>
+			<size>0x24</size>
+			<usage>registers</usage>
+		</addressBlock>
+
+		<interrupt>
+			<name>I2S</name>
+			<description>I2S interrupt</description>
+			<value>39</value>
+		</interrupt>
+		<registers>
+
+			<register>
+				<name>OUT1L</name>
+				<description>I2S Channel 1 LSBs</description>
+				<addressOffset>0x00</addressOffset>
+				<size>16</size>
+				<fields>
+						<field>
+							<description>I2S Ch1 lsb</description>
+							<name>OUT1_LSB</name>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+				</fields>
+			</register>
+
+			<register>
+				<name>OUT1H</name>
+				<description>I2S Channel 1 MSBs</description>
+				<addressOffset>0x04</addressOffset>
+				<size>16</size>
+				<fields>
+						<field>
+							<description>I2S Ch1 msb</description>
+							<name>OUT1_MSB</name>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+				</fields>
+			</register>
+
+			<register>
+				<name>OUT2L</name>
+				<description>I2S Channel 2 LSBs</description>
+				<addressOffset>0x08</addressOffset>
+				<size>16</size>
+				<fields>
+						<field>
+							<description>I2S Ch2 lsb</description>
+							<name>OUT2_LSB</name>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+				</fields>
+			</register>
+			<register>
+				<name>OUT2H</name>
+				<description>I2S Channel 2 MSBs</description>
+				<addressOffset>0x0C</addressOffset>
+				<size>16</size>
+				<fields>
+						<field>
+							<description>I2S Ch2 msb</description>
+							<name>OUT2_MSB</name>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+				</fields>
+			</register>
+
+				<register>
+					<name>MODE1</name>
+					<description>I2S I2S format modes 1</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>MODE2</name>
+					<description>I2S I2S format modes 2</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>CFG1</name>
+					<description>I2S I2S configuration 1</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>CFG2</name>
+					<description>I2S I2S configuration 2</description>
+					<addressOffset>0x1C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>STAT</name>
+					<description>I2S I2S status</description>
+					<addressOffset>0x20</addressOffset>
+					<size>16</size>
+				</register>
+			</registers>
+	</peripheral>
+	
+		<peripheral>
+			<name>ADI_BEEP</name>
+			
+			<description>Beeper</description>
+			<groupName>BEEP</groupName>
+			<baseAddress>0x40005C00</baseAddress>
+			<size>0x10</size>
+
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x10</size>
+				<usage>registers</usage>
+			</addressBlock>
+
+			<interrupt>
+				<name>BEEP</name>
+				<description>Beep interrupt</description>
+				<value>45</value>
+			</interrupt>
+			<registers>
+
+				<register>
+					<name>BEEP_CFG</name>
+					<description>BEEP Beeper configuration</description>
+					<addressOffset>0x00</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>STAT</name>
+					<description>BEEP Beeper status</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>TONE_A</name>
+					<description>BEEP Tone A Data</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>TONE_B</name>
+					<description>BEEP Tone B Data</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
+				</register>
+			</registers>
+	</peripheral>
+	
+		<peripheral>
+			<name>ADI_RNG</name>
+			
+			<description>Random Bit Generator</description>
+			<groupName>RBG</groupName>
+			<baseAddress>0x40006000</baseAddress>
+			<size>32</size>
+
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x18</size>
+				<usage>registers</usage>
+			</addressBlock>
+
+			<interrupt>
+				<name>RAND</name>
+				<description>Random Bit Generator interrupt</description>
+				<value>58</value>
+			</interrupt>
+			<registers>
+
+				<register>
+					<name>RNGCTL</name>
+					<description>RNG RNG Control Register</description>
+					<addressOffset>0x00</addressOffset>
+					<size>16</size>
+					<fields>
+                    <field>
+                        <name>TMRMODE</name>
+                        <description> Timer Mode</description>
+                        <bitOffset>2</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>CNTEN</name>
+                        <description> Oscillator Counter Enable</description>
+                        <bitOffset>1</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>RNGEN</name>
+                        <description> RNG Enable</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+					</fields>
+				</register>
+
+				<register>
+					<name>RNGLEN</name>
+					<description>RNG RNG Sample Length Register</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>
+					<fields>
+                    <field>
+                        <name>LENPRE</name>
+                        <description> Prescaler for the sample counter</description>
+                        <bitOffset>12</bitOffset>
+                        <bitWidth>4</bitWidth>
+                    </field>
+                    <field>
+                        <name>LENRLD</name>
+                        <description> Reload value for the sample counter</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>12</bitWidth>
+                    </field>
+					</fields>
+				</register>
+
+				<register>
+					<name>RNGSTAT</name>
+					<description>RNG RNG Status Register</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
+					<fields>
+                    <field>
+                        <name>RNGRDY</name>
+                        <description> Random number ready</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+					</fields>
+				</register>
+
+				<register>
+					<name>RNGDATA</name>
+					<description>RNG RNG Data Register</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>RNGCNTL</name>
+					<description>RNG Oscillator Count Low</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>
+					<access>read-only</access>					
+				</register>
+
+				<register>
+					<name>RNGCNTH</name>
+					<description>RNG Oscillator Count High</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
+					<access>read-only</access>					
+					<fields>
+                    <field>
+                        <name>RNGCNTH</name>
+                        <description> Upper bits of oscillator count</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>12</bitWidth>
+                    </field>
+					</fields>
+				</register>
+			</registers>
+		</peripheral>
+	
+		<peripheral>
+			<name>ADI_LCD</name>
+			<description>LCD Controller</description>
+			<groupName>LCD</groupName>
+			<baseAddress>0x40008000</baseAddress>
+			<size>32</size>
+
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x50</size>
+				<usage>registers</usage>
+			</addressBlock>
+
+			<interrupt>
+				<name>LCD</name>
+				<description>LCD Controller interrupt</description>
+				<value>46</value>
+			</interrupt>
+			<registers>
+
+				<register>
+					<name>LCDCON</name>
+					<description>LCD LCD Configuration Register</description>
+					<addressOffset>0x00</addressOffset>
+					<size>16</size>
+                <fields>
+                    <field>
+                        <name>BLINKEN</name>
+                        <description> Blink Mode Enable</description>
+                        <bitOffset>12</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>CPINT</name>
+                        <description> Enable Charge Pump interrupt</description>
+                        <bitOffset>11</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>FRAMEINT</name>
+                        <description> Enable frame boundary interrupt</description>
+                        <bitOffset>10</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>LCDRST</name>
+                        <description> LCD Data registers reset</description>
+                        <bitOffset>9</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>FRAMEINV</name>
+                        <description> Frame inversion mode enable</description>
+                        <bitOffset>8</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>FRAMESEL</name>
+                        <description> LCD frame rate select</description>
+                        <bitOffset>4</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>SCREENSEL</name>
+                        <description> Screen Select</description>
+                        <bitOffset>3</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>LCDMUX</name>
+                        <description> LCD Multiplex Value</description>
+                        <bitOffset>1</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>LCDEN</name>
+                        <description> LCD Enable</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                </fields>
+				</register>
+
+				<register>
+					<name>LCDSTAT</name>
+					<description>LCD LCD Status Register</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>
+					<fields>
+                    <field>
+                        <name>LCD</name>
+                        <description> LCD IDLE state</description>
+                        <bitOffset>4</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>VLCD</name>
+                        <description> VLCD update complete</description>
+                        <bitOffset>3</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>CP</name>
+                        <description> Charge pump good</description>
+                        <bitOffset>2</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>SAFE</name>
+                        <description> Safe to write the registers</description>
+                        <bitOffset>1</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>FRAMEINT</name>
+                        <description> LCD Frame boundary interrupt</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+					</fields>
+				</register>
+
+				<register>
+					<name>LCDBLINK</name>
+					<description>LCD LCD Blink Control Register</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
+					<fields>
+                    <field>
+                        <name>AUTOSWITCH</name>
+                        <description> Switch screen automatically</description>
+                        <bitOffset>5</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>BLKFREQ</name>
+                        <description> Blink rate configuration bits</description>
+                        <bitOffset>2</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>BLKMOD</name>
+                        <description> Blink mode clock source configuration bits</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+					</fields>
+				</register>
+
+				<register>
+					<name>LCDCONTRAST</name>
+					<description>LCD LCD Contrast Control Register</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
+					<fields>
+                    <field>
+                        <name>CP_PD</name>
+                        <description> Charge pump power down</description>
+                        <bitOffset>6</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>CP_EN</name>
+                        <description> Charge pump enable</description>
+                        <bitOffset>5</bitOffset>
+                        <bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>							
+                    </field>
+                    <field>
+                        <name>BIASLVL</name>
+                        <description> Bias level selection</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>4</bitWidth>
+                    </field>
+					</fields>
+				</register>
+
+				<register>
+					<name>LCDDATA0_S0</name>
+					<description>LCD Screen 0 LCD Data Register n</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA1_S0</name>
+					<description>LCD Screen 0 LCD Data Register n</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA2_S0</name>
+					<description>LCD Screen 0 LCD Data Register n</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA3_S0</name>
+					<description>LCD Screen 0 LCD Data Register n</description>
+					<addressOffset>0x1C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA4_S0</name>
+					<description>LCD Screen 0 LCD Data Register n</description>
+					<addressOffset>0x20</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA5_S0</name>
+					<description>LCD Screen 0 LCD Data Register n</description>
+					<addressOffset>0x24</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA6_S0</name>
+					<description>LCD Screen 0 LCD Data Register n</description>
+					<addressOffset>0x28</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA7_S0</name>
+					<description>LCD Screen 0 LCD Data Register n</description>
+					<addressOffset>0x2C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA0_S1</name>
+					<description>LCD Screen 1 LCD Data Register n</description>
+					<addressOffset>0x30</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA1_S1</name>
+					<description>LCD Screen 1 LCD Data Register n</description>
+					<addressOffset>0x34</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA2_S1</name>
+					<description>LCD Screen 1 LCD Data Register n</description>
+					<addressOffset>0x38</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA3_S1</name>
+					<description>LCD Screen 1 LCD Data Register n</description>
+					<addressOffset>0x3C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA4_S1</name>
+					<description>LCD Screen 1 LCD Data Register n</description>
+					<addressOffset>0x40</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA5_S1</name>
+					<description>LCD Screen 1 LCD Data Register n</description>
+					<addressOffset>0x44</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA6_S1</name>
+					<description>LCD Screen 1 LCD Data Register n</description>
+					<addressOffset>0x48</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LCDDATA7_S1</name>
+					<description>LCD Screen 1 LCD Data Register n</description>
+					<addressOffset>0x4C</addressOffset>
+					<size>16</size>
+				</register>
+			</registers>
+		</peripheral>
+		
+	<peripheral>
+		<name>ADI_DMA</name>
+		<description>DMA</description>
+		<groupName>DMAC</groupName>
+		<baseAddress>0x40010000</baseAddress>
+		<size>32</size>
+
+		<addressBlock>
+			<offset>0</offset>
+			<size>0x1000</size>
+			<usage>registers</usage>
+		</addressBlock>
+
+		<interrupt>
+			<name>DMA_ERR</name>
+			<description>DMA interrupt</description>
+			<value>19</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_SPIH_TX</name>
+			<description>DMA Ch 0 interrupt</description>
+			<value>20</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_SPIH_RX</name>
+			<description>DMA Ch 1 interrupt</description>
+			<value>21</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_SPI0_TX</name>
+			<description>DMA Ch 2 interrupt</description>
+			<value>22</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_SPI0_RX</name>
+			<description>DMA Ch 3 interrupt</description>
+			<value>23</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_SPI1_TX</name>
+			<description>DMA Ch 4 interrupt</description>
+			<value>24</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_SPI1_RX</name>
+			<description>DMA Ch 5 interrupt</description>
+			<value>25</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_UART_TX</name>
+			<description>DMA Ch 6 interrupt</description>
+			<value>26</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_UART_RX</name>
+			<description>DMA Ch 7 interrupt</description>
+			<value>27</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_I2CS_TX</name>
+			<description>DMA Ch 8 interrupt</description>
+			<value>28</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_I2CS_RX</name>
+			<description>DMA Ch 9 interrupt</description>
+			<value>29</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_I2CM</name>
+			<description>DMA Ch 10 interrupt</description>
+			<value>30</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_AFE_TX</name>
+			<description>DMA Ch 11 interrupt</description>
+			<value>31</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_AFE_RX</name>
+			<description>DMA Ch 12 interrupt</description>
+			<value>32</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_CRC</name>
+			<description>DMA Ch 13 interrupt</description>
+			<value>33</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_PDI</name>
+			<description>DMA Ch 14 interrupt</description>
+			<value>34</value>
+		</interrupt>
+		<interrupt>
+			<name>DMA_I2S</name>
+			<description>DMA Ch 15 interrupt</description>
+			<value>35</value>
+		</interrupt>		
+		<registers>
+
+	<register>
+		<name>DMASTA</name>
+		<description>DMA DMA Status</description>
+		<addressOffset>0x00</addressOffset>
+		<fields>
+                    <field>
+                        <name>CHNLSM1</name>
+                        <description> Number of available DMA channels minus 1</description>
+                        <bitOffset>16</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>STATE</name>
+                        <description> Current state of DMA controller</description>
+                        <bitOffset>4</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                    <field>
+                        <name>MENABLE</name>
+                        <description> Enable status of the controller</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+						<writeConstraint>
+						<useEnumeratedValues>true</useEnumeratedValues>
+						</writeConstraint>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>						
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMACFG</name>
+		<description>DMA DMA Configuration</description>
+		<addressOffset>0x04</addressOffset>
+		<fields>
+                    <field>
+                        <name>MENABLE</name>
+                        <description> Controller enable</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+						<writeConstraint>
+						<useEnumeratedValues>true</useEnumeratedValues>
+						</writeConstraint>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>							
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAPDBPTR</name>
+		<description>DMA DMA channel primary control data base pointer</description>
+		<addressOffset>0x08</addressOffset>
+		<size>32</size>
+	</register>
+
+	<register>
+		<name>DMAADBPTR</name>
+		<description>DMA DMA channel alternate control data base pointer</description>
+		<addressOffset>0x0C</addressOffset>
+		<size>32</size>
+	</register>
+
+	<register>
+		<name>DMASWREQ</name>
+		<description>DMA DMA channel software request</description>
+		<addressOffset>0x14</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHSWREQ</name>
+                        <description> Generate software request</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMARMSKSET</name>
+		<description>DMA DMA channel request mask set</description>
+		<addressOffset>0x20</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHREQMSET</name>
+                        <description> Mask requests from DMA channels</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMARMSKCLR</name>
+		<description>DMA DMA channel request mask clear</description>
+		<addressOffset>0x24</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHREQMCLR</name>
+                        <description> Clear REQ_MASK_SET bits in DMARMSKSET</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAENSET</name>
+		<description>DMA DMA channel enable set</description>
+		<addressOffset>0x28</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHENSET</name>
+                        <description> Enable DMA channels</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAENCLR</name>
+		<description>DMA DMA channel enable clear</description>
+		<addressOffset>0x2C</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHENCLR</name>
+                        <description> Disable DMA channels</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAALTSET</name>
+		<description>DMA DMA channel primary-alternate set</description>
+		<addressOffset>0x30</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHPRIALTSET</name>
+                        <description> Control struct status / select alt struct</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAALTCLR</name>
+		<description>DMA DMA channel primary-alternate clear</description>
+		<addressOffset>0x34</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHPRIALTCLR</name>
+                        <description> Select primary data struct</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAPRISET</name>
+		<description>DMA DMA channel priority set</description>
+		<addressOffset>0x38</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHPRISET</name>
+                        <description> Configure channel for high priority</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAPRICLR</name>
+		<description>DMA DMA channel priority clear</description>
+		<addressOffset>0x3C</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHPRICLR</name>
+                        <description> Configure channel for default priority level</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAERRCHNLCLR</name>
+		<description>DMA DMA Per Channel Error Clear</description>
+		<addressOffset>0x48</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHNL</name>
+                        <description> Per channel Bus error status/ Per channel bus error clear</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAERRCLR</name>
+		<description>DMA DMA bus error clear</description>
+		<addressOffset>0x4C</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>ERRCLR</name>
+                        <description> Bus error status</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMAINVALIDDESCCLR</name>
+		<description>DMA DMA Per Channel Invalid Descriptor Clear</description>
+		<addressOffset>0x50</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHNL</name>
+                        <description> Per channel Invalid Descriptor status/ Per channel Invalid descriptor status clear</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMABSSET</name>
+		<description>DMA DMA channel bytes swap enable set</description>
+		<addressOffset>0x0800</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHBSWAPSET</name>
+                        <description> Byte swap status</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMABSCLR</name>
+		<description>DMA DMA channel bytes swap enable clear</description>
+		<addressOffset>0x0804</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHBSWAPCLR</name>
+                        <description> Disable byte swap</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMASRCADSSET</name>
+		<description>DMA DMA channel source address decrement enable set</description>
+		<addressOffset>0x0810</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHSRCADRDECSET</name>
+                        <description> Source Address decrement status / configure Source address decrement</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMASRCADCLR</name>
+		<description>DMA DMA channel source address decrement enable clear</description>
+		<addressOffset>0x0814</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHADRDECCLR</name>
+                        <description> Disable source address decrement</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMADSTADSET</name>
+		<description>DMA DMA channel destination address decrement enable set</description>
+		<addressOffset>0x0818</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHDSTADRDECSET</name>
+                        <description> Destination Address decrement status / configure destination address decrement</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+	<register>
+		<name>DMADSTADCLR</name>
+		<description>DMA DMA channel destination address decrement enable clear</description>
+		<addressOffset>0x081C</addressOffset>
+		<size>16</size>
+		<fields>
+                    <field>
+                        <name>CHADRDECCLR</name>
+                        <description> Disable destination address decrement</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>16</bitWidth>
+                    </field>
+		</fields>
+	</register>
+
+				<register>
+					<name>DMAREVID</name>
+					<description>DMA DMA Controller Revision ID</description>
+					<addressOffset>0x0FE0</addressOffset>
+					<size>8</size>
+				</register>
+			</registers>
+		</peripheral>
+		
+	<peripheral>
+	<name>ADI_FEE0</name>
+	
+	<description>Instruction Flash Controller</description>
+	<groupName>IFC</groupName>
+	<baseAddress>0x40018000</baseAddress>
+	<size>32</size>
+
+	<addressBlock>
+	<offset>0</offset>
+	<size>0x88</size>
+	<usage>registers</usage>
+	</addressBlock>
+	<interrupt>
+		<name>FLASH0</name>
+		<description>Flash Controller Interrupt</description>		
+		<value>13</value>
+	</interrupt>
+	<interrupt>
+	<name>GP_FLASH</name>
+	<description>Flash EEPROM interrupt</description>
+	<value>55</value>
+	</interrupt>
+		<registers>
+
+	<register>
+		<name>FEESTA</name>
+		<description>FEE0 Status</description>
+		<addressOffset>0x00</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEECON0</name>
+		<description>FEE0 Command Control</description>
+		<addressOffset>0x04</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEECMD</name>
+		<description>FEE0 Command</description>
+		<addressOffset>0x08</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEADR0L</name>
+		<description>FEE0 Lower page address</description>
+		<addressOffset>0x10</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEADR0H</name>
+		<description>FEE0 Upper page address</description>
+		<addressOffset>0x14</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEADR1L</name>
+		<description>FEE0 Lower page address</description>
+		<addressOffset>0x18</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEADR1H</name>
+		<description>FEE0 Upper page address</description>
+		<addressOffset>0x1C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEKEY</name>
+		<description>FEE0 Key</description>
+		<addressOffset>0x20</addressOffset>
+		<size>16</size>
+		<fields>
+				<field>
+					<name>KEY</name>
+					<description>Lock for FEE</description>
+					<bitOffset>0</bitOffset>		
+					<bitWidth>16</bitWidth>	
+					<writeConstraint>
+					<useEnumeratedValues>true</useEnumeratedValues>
+					</writeConstraint>
+					<enumeratedValues>
+							<enumeratedValue>
+								<description>Magic Key 1</description>
+								<name>KEY1</name>
+								<value>0xF456</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Magic Key 2</description>							
+								<name>KEY2</name>
+								<value>0xF123</value>
+							</enumeratedValue>
+					</enumeratedValues>
+				</field>
+		</fields>
+	</register>
+
+	<register>
+		<name>FEESIGL</name>
+		<description>FEE0 Lower halfword of signature</description>
+		<addressOffset>0x30</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEESIGH</name>
+		<description>FEE0 Upper halfword of signature</description>
+		<addressOffset>0x34</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEADRAL</name>
+		<description>FEE0 Lower halfword of write abort address</description>
+		<addressOffset>0x48</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEADRAH</name>
+		<description>FEE0 Upper halfword of write abort address</description>
+		<addressOffset>0x4C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEPARCTL</name>
+		<description>FEE0 Parity Control Register</description>
+		<addressOffset>0x50</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEPARSTA</name>
+		<description>FEE0 Parity Status Register</description>
+		<addressOffset>0x54</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEPARADRL</name>
+		<description>FEE0 Parity Error Address Low</description>
+		<addressOffset>0x58</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEPARADRH</name>
+		<description>FEE0 Parity Error Address High</description>
+		<addressOffset>0x5C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEAEN0</name>
+		<description>FEE0 System IRQ abort enable for interrupts 15 to 0</description>
+		<addressOffset>0x78</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEAEN1</name>
+		<description>FEE0 System IRQ abort enable for interrupts 31 to 16</description>
+		<addressOffset>0x7C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEAEN2</name>
+		<description>FEE0 System IRQ abort enable for interrupts 47 to 32</description>
+		<addressOffset>0x80</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FEEAEN3</name>
+		<description>FEE0 System IRQ abort enable for interrupts 60 to 48</description>
+		<addressOffset>0x84</addressOffset>
+		<size>16</size>
+	</register>
+	</registers>
+	</peripheral>
+	
+	<peripheral>
+	<name>ADI_GPF</name>
+	
+	<description>General Purpose Flash Controller</description>
+	<groupName>GPFC</groupName>
+	<baseAddress>0x4001C000</baseAddress>
+	<size>0x88</size>
+
+	<addressBlock>
+	<offset>0</offset>
+	<size>0x88</size>
+	<usage>registers</usage>
+	</addressBlock>
+
+	<registers>
+
+	<register>
+		<name>GPFEESTA</name>
+		<description>GPF Status</description>
+		<addressOffset>0x00</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEECON0</name>
+		<description>GPF Command Control</description>
+		<addressOffset>0x04</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEECMD</name>
+		<description>GPF Command</description>
+		<addressOffset>0x08</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEEADR0L</name>
+		<description>GPF Lower page address</description>
+		<addressOffset>0x10</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEEADR1L</name>
+		<description>GPF Lower page address</description>
+		<addressOffset>0x18</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEEKEY</name>
+		<description>GPF Key</description>
+		<addressOffset>0x20</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEESIGL</name>
+		<description>GPF Lower halfword of signature</description>
+		<addressOffset>0x30</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEESIGH</name>
+		<description>GPF Upper halfword of signature</description>
+		<addressOffset>0x34</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEEADRAL</name>
+		<description>GPF Lower halfword of write abort address</description>
+		<addressOffset>0x48</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEEADRAH</name>
+		<description>GPF Upper halfword of write abort address</description>
+		<addressOffset>0x4C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEEAEN0</name>
+		<description>GPF System IRQ abort enable for interrupts 15 to 0</description>
+		<addressOffset>0x78</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEEAEN1</name>
+		<description>GPF System IRQ abort enable for interrupts 31 to 16</description>
+		<addressOffset>0x7C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEEAEN2</name>
+		<description>GPF System IRQ abort enable for interrupts 47 to 32</description>
+		<addressOffset>0x80</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPFEEAEN3</name>
+		<description>GPF System IRQ abort enable for interrupts 60 to 48</description>
+		<addressOffset>0x84</addressOffset>
+		<size>16</size>
+	</register>
+	</registers>
+	</peripheral>
+	
+	<peripheral>
+	<name>ADI_GPIO0</name>
+	
+	<description>GPIO</description>
+	<groupName>GPIO</groupName>
+	<baseAddress>0x40020000</baseAddress>
+	<size>0x32</size>
+
+	<addressBlock>
+	<offset>0</offset>
+	<size>0x32</size>
+	<usage>registers</usage>
+	</addressBlock>
+
+	<interrupt>
+	<name>GPIOA</name>
+	<description>interrupt</description>
+	<value>47</value>
+	</interrupt>
+	<interrupt>
+	<name>GPIOB</name>
+	<description>interrupt</description>
+	<value>48</value>
+	</interrupt>	
+		<registers>
+
+	<register>
+		<name>GPCON</name>
+		<description>GPIO0 GPIO Port 0 Configuration</description>
+		<addressOffset>0x00</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPOEN</name>
+		<description>GPIO0 GPIO Port 0 output enable</description>
+		<addressOffset>0x04</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPPE</name>
+		<description>GPIO0 GPIO Port 0 output pullup/pulldown enable</description>
+		<addressOffset>0x08</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPIEN</name>
+		<description>GPIO0 GPIO Port 0 Input Path Enable</description>
+		<addressOffset>0x0C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPIN</name>
+		<description>GPIO0 GPIO Port 0 registered data input</description>
+		<addressOffset>0x10</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPOUT</name>
+		<description>GPIO0 GPIO Port 0 data output</description>
+		<addressOffset>0x14</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPSET</name>
+		<description>GPIO0 GPIO Port 0 data out set</description>
+		<addressOffset>0x18</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPCLR</name>
+		<description>GPIO0 GPIO Port 0 data out clear</description>
+		<addressOffset>0x1C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPTGL</name>
+		<description>GPIO0 GPIO Port 0 pin toggle</description>
+		<addressOffset>0x20</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPPOL</name>
+		<description>GPIO0 GPIO Port 0 interrupt polarity</description>
+		<addressOffset>0x24</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPIENA</name>
+		<description>GPIO0 GPIO Port 0 interrupt A enable</description>
+		<addressOffset>0x28</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPIENB</name>
+		<description>GPIO0 GPIO Port 0 interrupt B enable</description>
+		<addressOffset>0x2C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>GPINT</name>
+		<description>GPIO0 GPIO Port 0 interrupt Status</description>
+		<addressOffset>0x30</addressOffset>
+		<size>16</size>
+	</register>
+	</registers>
+	</peripheral>
+	<peripheral derivedFrom=ADI_GPIO0>
+	<name>ADI_GPIO1</name>
+	<baseAddress>0x40020040</baseAddress>
+	</peripheral>
+	<peripheral derivedFrom=ADI_GPIO0>
+	<name>ADI_GPIO2</name>
+	<baseAddress>0x40020080</baseAddress>
+	</peripheral>	
+	<peripheral derivedFrom=ADI_GPIO0>
+	<name>ADI_GPIO3</name>
+	<baseAddress>0x400200C0</baseAddress>
+	</peripheral>
+	<peripheral derivedFrom=ADI_GPIO0>
+	<name>ADI_GPIO4</name>
+	<baseAddress>0x40020100</baseAddress>
+	</peripheral>
+	<peripheral>
+	<name>ADI_SPIH</name>
+	<description>SPIH Master/Slave</description>
+	<groupName>SPIH</groupName>
+	<baseAddress>0x40024000</baseAddress>
+	<size>32</size>
+
+	<addressBlock>
+	<offset>0</offset>
+	<size>0x1c</size>
+	<usage>registers</usage>
+	</addressBlock>
+
+	<interrupt>
+	<name>SPIH</name>
+	<description>interrupt</description>
+	<value>16</value>
+	</interrupt>
+				<registers>	
+				<register>
+					<name>SPISTA</name>
+					<description>SPIH Status</description>
+					<addressOffset>0x00</addressOffset>
+					<fields>
+						<field>
+							<name>CSRSG</name>
+							<description> Detected a rising edge on CS, in CONT mode</description>
+							<bitOffset>14</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CSFLG</name>
+							<description> Detected a falling edge on CS, in CONT mode</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CSERR</name>
+							<description> Detected a CS error condition</description>
+							<bitOffset>12</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RXS</name>
+							<description> SPI Rx FIFO excess bytes present</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RXFSTA</name>
+							<description> SPI Rx FIFO status</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>3</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>RX FIFO Empty</description>							
+								<name>EMPTY</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>1 Valid Byte in FIFO</description>
+								<name>FIFO1</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>2 Valid Bytes in FIFO</description>							
+								<name>FIFO2</name>
+								<value>2</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>3 Valid Bytes in FIFO</description>							
+								<name>FIFO3</name>
+								<value>3</value>
+							</enumeratedValue>							
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>RXOF</name>
+							<description>SPI Rx FIFO overflow</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RX</name>
+							<description>SPI Rx IRQ</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TX</name>
+							<description>SPI Tx IRQ</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TXUR</name>
+							<description> SPI Tx FIFO underflow</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>TXFSTA</name>
+							<description> SPI Tx FIFO status</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>3</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>TX FIFO Empty</description>							
+								<name>EMPTY</name>
+								<value>0</value>
+							</enumeratedValue>	
+							<enumeratedValue>
+								<description>1 Valid Byte in FIFO</description>
+								<name>FIFO1</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>2 Valid Bytes in FIFO</description>							
+								<name>FIFO2</name>
+								<value>2</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>3 Valid Bytes in FIFO</description>							
+								<name>FIFO3</name>
+								<value>3</value>
+							</enumeratedValue>							
+						</enumeratedValues>	
+						</field>
+						<field>
+							<name>IRQ</name>
+							<description> SPI Interrupt status</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPIRX</name>
+					<description>SPIH Receive</description>
+					<addressOffset>0x04</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>DMA</name>
+							<description> 8-bit receive buffer</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+						<field>
+							<name>DATA</name>
+							<description> 8-bit receive buffer</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPITX</name>
+					<description>SPIH Transmit</description>
+					<addressOffset>0x08</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>DMA</name>
+							<description> 8-bit transmit buffer</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+						<field>
+							<name>DATA</name>
+							<description> 8-bit transmit buffer</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPIDIV</name>
+					<description>SPIH Baud rate selection</description>
+					<addressOffset>0x0C</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>CSIRQ</name>
+							<description> Enable interrupt on every CS edge in CONT mode</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MD</name>
+							<description> Reset Mode for CSERR</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>HFM</name>
+							<description> High Frequency Mode</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>DIV</name>
+							<description> SPI clock divider</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>6</bitWidth>
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPICON</name>
+					<description>SPIH SPI configuration</description>
+					<addressOffset>0x10</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>MOD</name>
+							<description> SPI IRQ mode bits</description>
+							<bitOffset>14</bitOffset>
+							<bitWidth>2</bitWidth>
+						</field>
+						<field>
+							<name>TFLUSH</name>
+							<description> SPI Tx FIFO Flush enable</description>
+							<bitOffset>13</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>RFLUSH</name>
+							<description> SPI Rx FIFO Flush enable</description>
+							<bitOffset>12</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CON</name>
+							<description> Continuous transfer enable</description>
+							<bitOffset>11</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>LOOPBACK</name>
+							<description> Loopback enable</description>
+							<bitOffset>10</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>OEN</name>
+							<description> Slave MISO output enable</description>
+							<bitOffset>9</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>RXOF</name>
+							<description> SPIRX overflow overwrite enable</description>
+							<bitOffset>8</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>ZEN</name>
+							<description> Transmit zeros enable</description>
+							<bitOffset>7</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>TIM</name>
+							<description> SPI transfer and interrupt mode</description>
+							<bitOffset>6</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>LSB</name>
+							<description> LSB first transfer enable</description>
+							<bitOffset>5</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>WOM</name>
+							<description> SPI Wired Or mode</description>
+							<bitOffset>4</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CPOL</name>
+							<description> Serial Clock Polarity</description>
+							<bitOffset>3</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>CPHA</name>
+							<description> Serial clock phase mode</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						</field>
+						<field>
+							<name>MASEN</name>
+							<description> Master mode enable</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>ENABLE</name>
+							<description>SPI enable</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPIDMA</name>
+					<description>SPIH SPI DMA enable</description>
+					<addressOffset>0x14</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>IENRXDMA</name>
+							<description> Enable receive DMA request</description>
+							<bitOffset>2</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>IENTXDMA</name>
+							<description> Enable transmit DMA request</description>
+							<bitOffset>1</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+						<field>
+							<name>ENABLE</name>
+							<description> Enable DMA for data transfer</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Enable</description>
+								<name>ENABLE</name>
+								<value>1</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Disable</description>							
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+						</enumeratedValues>								
+						</field>
+					</fields>
+				</register>
+
+				<register>
+					<name>SPICNT</name>
+					<description>SPIH Transfer byte count</description>
+					<addressOffset>0x18</addressOffset>
+					<size>16</size>
+					<fields>
+						<field>
+							<name>COUNT</name>
+							<description> Transfer byte count</description>
+							<bitOffset>0</bitOffset>
+							<bitWidth>8</bitWidth>
+						</field>
+					</fields>
+				</register>
+			</registers>
+	</peripheral>
+	
+	<peripheral>
+	<name>ADI_SYSCLK</name>
+	
+	<description>System Clocking</description>
+	<groupName>SYSCLK</groupName>
+	<baseAddress>0x40028000</baseAddress>
+	<size>32</size>
+
+	<addressBlock>
+	<offset>0</offset>
+	<size>32</size>
+	<usage>registers</usage>
+	</addressBlock>
+
+	<registers>
+
+	<register>
+		<name>CLKCON0</name>
+		<description>Clock Control Register 0</description>
+		<addressOffset>0x00</addressOffset>
+		<size>16</size>
+		<fields>
+			<field>
+				<name>HFXTALIE</name>
+						<description>HF Crystal Interupt Enable</description>
+						<bitOffset>15</bitOffset>
+						<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Disable Interrupt Generation</description>
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Enable Interrupt Generation</description>								
+								<name>ENABLE</name>
+								<value>1</value>								
+							</enumeratedValue>
+						</enumeratedValues>
+			</field>
+			<field>
+				<name>LFXTALIE</name>
+						<description>LF Crystal Interupt Enable</description>
+						<bitOffset>14</bitOffset>
+						<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Disable Interrupt Generation</description>
+								<name>DISABLE</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Enable Interrupt Generation</description>								
+								<name>ENABLE</name>
+								<value>1</value>								
+							</enumeratedValue>
+						</enumeratedValues>
+			</field>
+			<field>
+				<name>PLLMUX</name>
+						<description>SPLL Mux selects which source clock is fed to the SPLL</description>
+						<bitOffset>11</bitOffset>
+						<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Internal RC</description>
+								<name>INTERNAL</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>External Crystal</description>								
+								<name>XTAL</name>
+								<value>1</value>								
+							</enumeratedValue>
+						</enumeratedValues>
+			</field>
+			<field>
+				<name>LFCLKMUX</name>
+						<description>32kHz clock select</description>
+						<bitOffset>8</bitOffset>
+						<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Internal RC</description>
+								<name>INTERNAL</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>External Crystal</description>								
+								<name>XTAL</name>
+								<value>1</value>								
+							</enumeratedValue>
+						</enumeratedValues>
+			</field>			
+			<field>
+				<name>CLKCOUT</name>
+						<description>GPIO clock out select</description>
+						<bitOffset>4</bitOffset>
+						<bitWidth>4</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Root Clock</description>
+								<name>ROOT_CLK</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>LF Clock</description>								
+								<name>LF_CLK</name>
+								<value>1</value>								
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Cap Touch Clock</description>
+								<name>CT_CLK</name>
+								<value>2</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>HCLK Bus Clock</description>								
+								<name>HCLK_BUS</name>
+								<value>3</value>								
+							</enumeratedValue>							
+							<enumeratedValue>
+								<description>HCLK Core Clock</description>								
+								<name>HCLK_CORE</name>
+								<value>4</value>								
+							</enumeratedValue>	
+							<enumeratedValue>
+								<description>P Clock</description>
+								<name>P_CLK</name>
+								<value>5</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>USB Control Clock</description>								
+								<name>USB_CTL_CLK</name>
+								<value>6</value>								
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>USB Phy Clock</description>
+								<name>USB_PHY_CLK</name>
+								<value>7</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>GPT0 Clock</description>
+								<name>GPT0_CLK</name>
+								<value>8</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>GPT1 Clock</description>								
+								<name>GPT1_CLK</name>
+								<value>9</value>								
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>GPT2 Clock</description>
+								<name>GPT2_CLK</name>
+								<value>10</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Wake Up Timer Clock</description>								
+								<name>WUT_CLK</name>
+								<value>11</value>								
+							</enumeratedValue>							
+							<enumeratedValue>
+								<description>RTC Count Clock</description>								
+								<name>RTC_CNT_CLK</name>
+								<value>12</value>								
+							</enumeratedValue>	
+						</enumeratedValues>
+			</field>
+			<field>
+				<name>CLKMUX</name>
+						<description>Clock Mux select</description>
+						<bitOffset>0</bitOffset>
+						<bitWidth>2</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>HF Internal</description>
+								<name>HFINT</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>HF External</description>								
+								<name>HFEXTERNAL</name>
+								<value>1</value>								
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>System PLL</description>
+								<name>SYSPLL</name>
+								<value>2</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>External GPIO</description>								
+								<name>GPIOEXTERNAL</name>
+								<value>3</value>								
+							</enumeratedValue>							
+						</enumeratedValues>
+			</field>			
+			
+		</fields>
+	</register>
+
+	<register>
+		<name>CLKCON1</name>
+		<description>Clock Control Register 0</description>
+		<addressOffset>0x04</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>CLKCON2</name>
+		<description>Clock Control Register 2</description>
+		<addressOffset>0x08</addressOffset>
+		<size>16</size>
+	</register>
+	<register>
+		<name>CLKCON3</name>
+		<description>Clock Control Register 3</description>
+		<addressOffset>0x0c</addressOffset>
+		<size>16</size>
+	</register>	
+	<register>
+		<name>CLKCON4</name>
+		<description>Clock Control Register 4</description>
+		<addressOffset>0x10</addressOffset>
+		<size>16</size>
+	</register>		
+	<register>
+		<name>CLKCON5</name>
+		<description>Clock Control Register 5</description>
+		<addressOffset>0x14</addressOffset>
+		<size>16</size>
+	</register>	
+	<register>
+		<name>CLKSTAT0</name>
+		<description>Clock Status Register 0</description>
+		<addressOffset>0x18</addressOffset>
+		<size>16</size>
+	</register>	
+	</registers>
+	</peripheral>
+
+	<peripheral>
+	<name>ADI_CRC</name>
+	
+	<description>CRC Engine</description>
+	<groupName>CRCENG</groupName>
+	<baseAddress>0x4002C000</baseAddress>
+	<size>32</size>
+
+	<addressBlock>
+	<offset>0</offset>
+	<size>0x36</size>
+	<usage>registers</usage>
+	</addressBlock>
+
+	<registers>
+
+	<register>
+		<name>CTL</name>
+		<description>CRC CRC Control Register</description>
+		<addressOffset>0x00</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>IPDATA</name>
+		<description>CRC Input Data Register</description>
+		<addressOffset>0x04</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>RESULT</name>
+		<description>CRC CRC Result Register</description>
+		<addressOffset>0x08</addressOffset>
+		<size>16</size>
+	</register>
+	</registers>
+	</peripheral>
+	
+	<peripheral>
+	<name>ADI_PDI</name>
+	
+	<description>Parallel Display Interface</description>
+	<groupName>PDIC</groupName>
+	<baseAddress>0x40030000</baseAddress>
+	<size>32</size>
+
+	<addressBlock>
+	<offset>0</offset>
+	<size>0x4c</size>
+	<usage>registers</usage>
+	</addressBlock>
+
+	<interrupt>
+	<name>PDI</name>
+	<description>Paraller Display Interface interrupt</description>
+	<value>59</value>
+	</interrupt>
+		<registers>
+
+	<register>
+		<name>CFG</name>
+		<description>PDI PDI Configuration Register</description>
+		<addressOffset>0x00</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>INT_SET</name>
+		<description>PDI PDI Interrupt Set Register</description>
+		<addressOffset>0x04</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>INT_CLR</name>
+		<description>PDI PDI Interrupt Clear Register</description>
+		<addressOffset>0x08</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>STAT</name>
+		<description>PDI PDI Status Register</description>
+		<addressOffset>0x0C</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+
+		<name>CMD</name>
+		<description>PDI PDI Command Register</description>
+		<addressOffset>0x10</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FRDATA_N</name>
+		<description>PDI PDI Frame Data Count Register</description>
+		<addressOffset>0x14</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>FIFO</name>
+		<description>PDI PDI Parameter FIFO</description>
+		<addressOffset>0x18</addressOffset>
+		<size>16</size>
+	</register>
+
+	<register>
+		<name>IF_TIMING</name>
+		<description>PDI PDI Interface Timing Register</description>
+		<addressOffset>0x1C</addressOffset>
+		<size>16</size>
+	</register>
+	</registers>
+	</peripheral>
+	
+	<peripheral>
+	<name>ADI_AFE</name>
+	
+	<description>Analog Front End</description>
+	<groupName>Analog Front End</groupName>
+	<baseAddress>0x40080000</baseAddress>
+	<size>32</size>
+
+	<addressBlock>
+	<offset>0</offset>
+	<size>0x148</size>
+	<usage>registers</usage>
+	</addressBlock>
+
+	<interrupt>
+	<name>AFE_CAPTURE</name>
+	<description>Analog Front End Capture interrupt</description>
+	<value>50</value>
+	</interrupt>
+	<interrupt>
+	<name>AFE_GENERATE</name>
+	<description>Analog Front End Generation interrupt</description>
+	<value>51</value>
+	</interrupt>
+	<interrupt>
+	<name>AFE_CMD_FIFO</name>
+	<description>Analog Front End FIFO CMD interrupt</description>
+	<value>52</value>
+	</interrupt>
+	<interrupt>
+		<name>AFE_DATA_FIFO</name>
+		<description>Analog Front End FIFO DATA interrupt</description>
+		<value>53</value>
+	</interrupt>	
+	<registers>
+		<register>
+			<name>CFG</name>
+			<description>AFE AFE Configuration</description>
+			<addressOffset>0x00</addressOffset>
+				<fields>
+					<field>
+						<name>ALDOILIMIT_EN</name>
+						<description>Enable LDO Current limit</description>
+						<bitOffset>19</bitOffset>
+						<bitWidth>1</bitWidth>
+						<enumeratedValues>
+							<enumeratedValue>
+								<description>Disable AFE LDO Buffer I limit</description>
+								<name>DISABLED</name>
+								<value>0</value>
+							</enumeratedValue>
+							<enumeratedValue>
+								<description>Enable AFE LDO Buffer I limit</description>								
+								<name>ENABLED</name>
+								<value>1</value>								
+							</enumeratedValue>
+						</enumeratedValues>
+					</field>
+				</fields>
+		</register>
+		<register>
+			<name>SEQ_CFG</name>
+			<description>AFE Sequencer Configuration</description>
+			<addressOffset>0x04</addressOffset>
+		</register>
+
+	<register>
+		<name>FIFO_CFG</name>
+		<description>AFE FIFOs Configuration</description>
+		<addressOffset>0x08</addressOffset>
+	</register>
+
+	<register>
+		<name>SW_CFG</name>
+		<description>AFE Switch Matrix Configuration</description>
+		<addressOffset>0x0C</addressOffset>
+	</register>
+
+	<register>
+		<name>DAC_CFG</name>
+		<description>AFE DAC Configuration</description>
+		<addressOffset>0x10</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_CFG</name>
+		<description>AFE Waveform Generator Configuration</description>
+		<addressOffset>0x14</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_DCLEVEL_1</name>
+		<description>AFE Waveform Generator - Trapezoid DC Level 1</description>
+		<addressOffset>0x18</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_DCLEVEL_2</name>
+		<description>AFE Waveform Generator - Trapezoid DC Level 2</description>
+		<addressOffset>0x1C</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_DELAY_1</name>
+		<description>AFE Waveform Generator - Trapezoid Delay 1 Time</description>
+		<addressOffset>0x20</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_SLOPE_1</name>
+		<description>AFE Waveform Generator - Trapezoid Slope 1 Time</description>
+		<addressOffset>0x24</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_DELAY_2</name>
+		<description>AFE Waveform Generator - Trapezoid Delay 2 Time</description>
+		<addressOffset>0x28</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_SLOPE_2</name>
+		<description>AFE Waveform Generator - Trapezoid Slope 2 Time</description>
+		<addressOffset>0x2C</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_FCW</name>
+		<description>AFE Waveform Generator - Sinusoid Frequency Control Word</description>
+		<addressOffset>0x30</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_PHASE</name>
+		<description>AFE Waveform Generator - Sinusoid Phase Offset</description>
+		<addressOffset>0x34</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_OFFSET</name>
+		<description>AFE Waveform Generator - Sinusoid Offset</description>
+		<addressOffset>0x38</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_AMPLITUDE</name>
+		<description>AFE Waveform Generator - Sinusoid Amplitude</description>
+		<addressOffset>0x3C</addressOffset>
+
+	</register>
+
+	<register>
+		<name>ADC_CFG</name>
+		<description>AFE ADC Configuration</description>
+		<addressOffset>0x40</addressOffset>
+	</register>
+
+	<register>
+		<name>SUPPLY_LPF_CFG</name>
+		<description>AFE Supply Rejection Filter Configuration</description>
+		<addressOffset>0x44</addressOffset>
+	</register>
+
+	<register>
+		<name>SW_FULL_CFG_MSB</name>
+		<description>AFE Switch Matrix Full Configuration (MSB)</description>
+		<addressOffset>0x48</addressOffset>
+	</register>
+
+	<register>
+		<name>SW_FULL_CFG_LSB</name>
+		<description>AFE Switch Matrix Full Configuration (LSB)</description>
+		<addressOffset>0x4C</addressOffset>
+	</register>
+
+	<register>
+		<name>WG_DAC_CODE</name>
+		<description>AFE Waveform Generator - DAC Code</description>
+		<addressOffset>0x54</addressOffset>
+	</register>
+
+	<register>
+		<name>STATUS</name>
+		<description>AFE AFE Status</description>
+		<addressOffset>0x58</addressOffset>
+	</register>
+
+	<register>
+		<name>SEQ_CRC</name>
+		<description>AFE Sequencer CRC Value</description>
+		<addressOffset>0x60</addressOffset>
+	</register>
+
+	<register>
+		<name>SEQ_COUNT</name>
+		<description>AFE Sequencer Command Count</description>
+		<addressOffset>0x64</addressOffset>
+	</register>
+
+	<register>
+		<name>SEQ_TIMEOUT</name>
+		<description>AFE Sequencer Timeout Counter</description>
+		<addressOffset>0x68</addressOffset>
+	</register>
+
+	<register>
+		<name>DATA_FIFO_READ</name>
+		<description>AFE Data FIFO Read</description>
+		<addressOffset>0x6C</addressOffset>
+	</register>
+
+	<register>
+		<name>CMD_FIFO_WRITE</name>
+		<description>AFE Command FIFO Write</description>
+		<addressOffset>0x70</addressOffset>
+	</register>
+
+	<register>
+		<name>ADC_RESULT</name>
+		<description>AFE ADC Raw Result</description>
+		<addressOffset>0x74</addressOffset>
+	</register>
+
+	<register>
+		<name>DFT_RESULT_REAL</name>
+		<description>AFE DFT Result, Real Part</description>
+		<addressOffset>0x78</addressOffset>
+	</register>
+
+	<register>
+		<name>DFT_RESULT_IMAG</name>
+		<description>AFE DFT Result, Imaginary Part</description>
+		<addressOffset>0x7C</addressOffset>
+	</register>
+
+	<register>
+		<name>SUPPLY_LPF_RESULT</name>
+		<description>AFE Supply Rejection Filter Result</description>
+		<addressOffset>0x80</addressOffset>
+	</register>
+
+	<register>
+		<name>TEMP_SENSOR_RESULT</name>
+		<description>AFE Temperature Sensor Result</description>
+		<addressOffset>0x84</addressOffset>
+	</register>
+
+	<register>
+		<name>ANALOG_CAPTURE_IEN</name>
+		<description>AFE Analog Capture Interrupt Enable</description>
+		<addressOffset>0x8C</addressOffset>
+	</register>
+
+	<register>
+		<name>ANALOG_GEN_IEN</name>
+		<description>AFE Analog Generation Interrupt Enable</description>
+		<addressOffset>0x90</addressOffset>
+	</register>
+
+	<register>
+		<name>CMD_FIFO_IEN</name>
+		<description>AFE Command FIFO Interrupt Enable</description>
+		<addressOffset>0x94</addressOffset>
+	</register>
+
+	<register>
+		<name>DATA_FIFO_IEN</name>
+		<description>AFE Data FIFO Interrupt Enable</description>
+		<addressOffset>0x98</addressOffset>
+	</register>
+
+	<register>
+		<name>ANALOG_CAPTURE_INT</name>
+		<description>AFE Analog Capture Interrupt</description>
+		<addressOffset>0xA0</addressOffset>
+	</register>
+
+	<register>
+		<name>ANALOG_GEN_INT</name>
+		<description>AFE Analog Generation Interrupt</description>
+		<addressOffset>0xA4</addressOffset>
+	</register>
+
+	<register>
+		<name>CMD_FIFO_INT</name>
+		<description>AFE Command FIFO Interrupt</description>
+		<addressOffset>0xA8</addressOffset>
+	</register>
+
+	<register>
+		<name>DATA_FIFO_INT</name>
+		<description>AFE Data FIFO Interrupt</description>
+		<addressOffset>0xAC</addressOffset>
+	</register>
+
+	<register>
+		<name>SW_STATUS_MSB</name>
+		<description>AFE Switch Matrix Status MSB</description>
+		<addressOffset>0xB0</addressOffset>
+	</register>
+
+	<register>
+		<name>SW_STATUS_LSB</name>
+		<description>AFE Switch Matrix Status (LSB)</description>
+		<addressOffset>0xB4</addressOffset>
+	</register>
+
+	<register>
+		<name>ADCMIN</name>
+		<description>AFE ADC Minimum Value Check</description>
+		<addressOffset>0xB8</addressOffset>
+	</register>
+
+	<register>
+		<name>ADCMAX</name>
+		<description>AFE ADC Maximum Value Check</description>
+		<addressOffset>0xBC</addressOffset>
+	</register>
+
+	<register>
+		<name>ADCDELTA</name>
+		<description>AFE ADC Delta Check</description>
+		<addressOffset>0xC0</addressOffset>
+	</register>
+
+	<register>
+		<name>CAL_DATA_LOCK</name>
+		<description>AFE Calibration Data Lock</description>
+		<addressOffset>0x0100</addressOffset>
+	</register>
+
+	<register>
+		<name>ADC_GAIN_TIA</name>
+		<description>AFE ADC Gain (TIA Measurement)</description>
+		<addressOffset>0x0104</addressOffset>
+	</register>
+
+	<register>
+		<name>ADC_OFFSET_TIA</name>
+		<description>AFE ADC Offset (TIA Measurement)</description>
+		<addressOffset>0x0108</addressOffset>
+	</register>
+
+	<register>
+		<name>ADC_GAIN_TEMP_SENS</name>
+		<description>AFE ADC Gain (Temperature Sensor Measurement)</description>
+		<addressOffset>0x010C</addressOffset>
+	</register>
+
+	<register>
+		<name>ADC_OFFSET_TEMP_SENS</name>
+		<description>AFE ADC Offset (Temperature Sensor Measurement)</description>
+		<addressOffset>0x0110</addressOffset>
+	</register>
+
+	<register>
+		<name>ADC_GAIN_AUX</name>
+		<description>AFE ADC Gain (Aux Channel Measurement)</description>
+		<addressOffset>0x0118</addressOffset>
+	</register>
+
+	<register>
+		<name>ADC_OFFSET_AUX</name>
+		<description>AFE ADC Offset (Aux Channel Measurement)</description>
+		<addressOffset>0x011C</addressOffset>
+	</register>
+
+	<register>
+		<name>DAC_OFFSET_UNITY</name>
+		<description>AFE DAC Offset With Attenuator Disabled</description>
+		<addressOffset>0x0120</addressOffset>
+	</register>
+
+	<register>
+		<name>DAC_OFFSET_ATTEN</name>
+		<description>AFE DAC Offset With Attenuator Enabled</description>
+		<addressOffset>0x0124</addressOffset>
+	</register>
+
+	<register>
+		<name>DAC_GAIN</name>
+		<description>AFE DAC Gain</description>
+		<addressOffset>0x0128</addressOffset>
+	</register>
+
+	<register>
+		<name>REF_TRIM0</name>
+		<description>AFE Precision Reference Trim 0</description>
+		<addressOffset>0x012C</addressOffset>
+
+	</register>
+
+	<register>
+		<name>REF_TRIM1</name>
+		<description>AFE Precision Reference Trim 1</description>
+		<addressOffset>0x0130</addressOffset>
+	</register>
+
+	<register>
+		<name>ALDO_TRIM</name>
+		<description>AFE Analog LDO Trim</description>
+		<addressOffset>0x0134</addressOffset>
+	</register>
+
+	<register>
+		<name>DAC_TRIM</name>
+		<description>AFE DAC Trim</description>
+		<addressOffset>0x0138</addressOffset>
+	</register>
+
+	<register>
+		<name>INAMP_TRIM</name>
+		<description>AFE INAMP Trim</description>
+		<addressOffset>0x013C</addressOffset>
+	</register>
+
+	<register>
+		<name>EXBUF_TRIM</name>
+		<description>AFE Excitation Buffer Trim</description>
+		<addressOffset>0x0140</addressOffset>
+	</register>
+
+	<register>
+		<name>TEMP_SENS_TRIM</name>
+		<description>AFE Temperature Sensor Trim</description>
+		<addressOffset>0x0144</addressOffset>
+	</register>
+	</registers>
+	</peripheral>
+	<peripheral>
+		<name>ADI_CT</name>
+		
+		<description>Cap Touch Controller</description>
+		<groupName>CT</groupName>
+		<baseAddress>0x40084000</baseAddress>
+		<size>32</size>
+
+		<addressBlock>
+		<offset>0</offset>
+		<size>0x12c</size>
+		<usage>registers</usage>
+		</addressBlock>		
+	<registers>
+	<register>
+		<name>CDC_PWR</name>
+		<description>Cap Touch </description>
+		<addressOffset>0x0</addressOffset>
+		<size>32</size>
+	</register>
+	<register>
+		<name>CFG1</name>
+		<description>Cap Touch Config Register 1</description>
+		<addressOffset>0x4</addressOffset>
+		<size>32</size>
+	</register>
+	<register>
+		<name>CFG2</name>
+		<description>Cap Touch Config Register 2</description>
+		<addressOffset>0x8</addressOffset>
+		<size>32</size>
+	</register>	
+	<register>
+		<name>CFG3</name>
+		<description>Cap Touch Config Register 3</description>
+		<addressOffset>0xc</addressOffset>
+		<size>32</size>
+	</register>
+	</registers>
+		
+	</peripheral>
+		
+	<peripheral>
+		<name>ADI_USB</name>
+		
+		<description>USB Controller</description>
+		<groupName>USB</groupName>
+		<baseAddress>0x400A0000</baseAddress>
+		<size>32</size>
+
+		<addressBlock>
+			<offset>0</offset>
+			<size>0x3B8</size>
+			<usage>registers</usage>
+		</addressBlock>
+		<interrupt>
+			<name>USB_WAKEUP</name>
+			<description>USB Wakeup interrupt</description>
+			<value>36</value>
+		</interrupt>
+		<interrupt>
+			<name>USB_CNTL</name>
+			<description>USB Controller interrupt</description>
+			<value>37</value>
+		</interrupt>
+		<interrupt>
+			<name>USB_DMA</name>
+			<description>USB DMA interrupt</description>
+			<value>38</value>
+		</interrupt>
+		<registers>
+			<register>
+				<name>FADDR</name>
+				<description>USB0 Function Address Register</description>
+				<addressOffset>0x00</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+				<name>POWER</name>
+				<description>USB0 Power and Device Control Register</description>
+				<addressOffset>0x01</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+				<name>INTRTX</name>
+				<description>USB0 Transmit Interrupt Register</description>
+				<addressOffset>0x02</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+				<name>INTRRX</name>
+				<description>USB0 Receive Interrupt Register</description>
+				<addressOffset>0x04</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>INTRTXE</name>
+				<description>USB0 Transmit Interrupt Enable Register</description>
+				<addressOffset>0x0006</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>INTRRXE</name>
+				<description>USB0 Receive Interrupt Enable Register</description>
+				<addressOffset>0x0008</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>IRQ</name>
+				<description>USB0 Common Interrupts Register</description>
+				<addressOffset>0x000A</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+				<name>IEN</name>
+				<description>USB0 Common Interrupts Enable Register</description>
+				<addressOffset>0x000B</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+				<name>FRAME</name>
+				<description>USB0 Frame Number Register</description>
+				<addressOffset>0x000C</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>INDEX</name>
+				<description>USB0 Index Register</description>
+				<addressOffset>0x000E</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+				<name>TESTMODE</name>
+				<description>USB0 Testmode Register</description>
+				<addressOffset>0x000F</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+				<name>EPI_TXMAXP0</name>
+				<description>USB0 EPn Transmit Maximum Packet Length Register</description>
+				<addressOffset>0x0010</addressOffset>
+				<size>16</size>
+			</register>
+<!--
+			<register>
+				<name>EPI_TXCSR_H0</name>
+				<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
+				<addressOffset>0x0012</addressOffset>
+				<size>16</size>
+			</register>
+-->
+<!--
+			<register>
+				<name>EP0I_CSR0_P</name>
+				<description>USB0 EP0 Configuration and Status (Peripheral) Register</description>
+				<addressOffset>0x0012</addressOffset>
+				<size>16</size>
+			</register>
+-->
+<!--
+			<register>
+				<name>EP0I_CSR0_H</name>
+				<description>USB0 EP0 Configuration and Status (Host) Register</description>
+				<addressOffset>0x0012</addressOffset>
+				<size>16</size>
+			</register>
+-->
+			<register>
+				<name>EPI_TXCSR_P0</name>
+				<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
+				<addressOffset>0x0012</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>EPI_RXMAXP0</name>
+				<description>USB0 EPn Receive Maximum Packet Length Register</description>
+				<addressOffset>0x0014</addressOffset>
+				<size>16</size>
+			</register>
+<!--
+			<register>
+				<name>EPI_RXCSR_H0</name>
+				<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
+				<addressOffset>0x0016</addressOffset>
+				<size>16</size>
+			</register>
+-->
+<!--
+			<register>
+				<name>EPI_RXCSR_P0</name>
+				<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
+				<addressOffset>0x0016</addressOffset>
+				<size>16</size>
+			</register>
+-->
+			<register>
+				<name>EP0I_CNT0</name>
+				<description>USB0 EP0 Number of Received Bytes Register</description>
+				<addressOffset>0x0018</addressOffset>
+				<size>16</size>
+			</register>
+<!--
+			<register>
+				<name>EPI_RXCNT0</name>
+				<description>USB0 EPn Number of Bytes Received Register</description>
+				<addressOffset>0x0018</addressOffset>
+				<size>16</size>
+			</register>
+-->
+			<register>
+				<name>EP0I_CFGDATA0</name>
+				<description>USB0 EP0 Configuration Information Register</description>
+				<addressOffset>0x001F</addressOffset>
+				<size>8</size>
+			</register>
+<!--
+			<register>
+				<name>EPI_FIFOSIZE0</name>
+				<description>USB0 FIFO size</description>
+				<addressOffset>0x001F</addressOffset>
+				<size>8</size>
+			</register>
+-->
+			<register>
+				<name>FIFO0</name>
+				<description>USB0 FIFO Word (32-Bit) Register</description>
+				<addressOffset>0x0020</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>FIFO1</name>
+				<description>USB0 FIFO Word (32-Bit) Register</description>
+				<addressOffset>0x0024</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>FIFO2</name>
+				<description>USB0 FIFO Word (32-Bit) Register</description>
+				<addressOffset>0x0028</addressOffset>
+			</register>
+
+			<register>
+				<name>FIFO3</name>
+				<description>USB0 FIFO Word (32-Bit) Register</description>
+				<addressOffset>0x002C</addressOffset>
+				<size>16</size>
+			</register>
+<!--
+			<register>
+				<name>FIFOH0</name>
+				<description>USB0 FIFO Half-Word (16-Bit) Register</description>
+				<addressOffset>0x0020</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>FIFOH1</name>
+				<description>USB0 FIFO Half-Word (16-Bit) Register</description>
+				<addressOffset>0x0024</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>FIFOH2</name>
+				<description>USB0 FIFO Half-Word (16-Bit) Register</description>
+				<addressOffset>0x0028</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>FIFOH3</name>
+				<description>USB0 FIFO Half-Word (16-Bit) Register</description>
+				<addressOffset>0x002C</addressOffset>
+				<size>16</size>
+			</register>
+-->
+<!--
+			<register>
+				<name>FIFOB0</name>
+				<description>USB0 FIFO Byte (8-Bit) Register</description>
+				<addressOffset>0x0020</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>FIFOB1</name>
+				<description>USB0 FIFO Byte (8-Bit) Register</description>
+				<addressOffset>0x0024</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>FIFOB2</name>
+				<description>USB0 FIFO Byte (8-Bit) Register</description>
+				<addressOffset>0x0028</addressOffset>
+				<size>16</size>
+			</register>
+
+			<register>
+				<name>FIFOB3</name>
+				<description>USB0 FIFO Byte (8-Bit) Register</description>
+				<addressOffset>0x002C</addressOffset>
+				<size>16</size>
+			</register>
+-->
+			<register>
+				<name>DEV_CTL</name>
+				<description>USB0 Device Control Register</description>
+				<addressOffset>0x0060</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+				<name>MISC</name>
+				<description>USB0 Miscellaneous Register</description>
+				<addressOffset>0x0061</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+				<name>EPINFO</name>
+				<description>USB0 Endpoint Information Register</description>
+				<addressOffset>0x0078</addressOffset>
+				<size>8</size>
+			</register>
+
+			<register>
+					<name>RAMINFO</name>
+					<description>USB0 RAM Information Register</description>
+					<addressOffset>0x0079</addressOffset>
+					<size>8</size>
+				</register>
+
+				<register>
+					<name>LINKINFO</name>
+					<description>USB0 Link Information Register</description>
+					<addressOffset>0x007A</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>FS_EOF1</name>
+					<description>USB0 Full-Speed EOF 1 Register</description>
+					<addressOffset>0x007D</addressOffset>
+					<size>8</size>
+
+				</register>
+
+				<register>
+					<name>SOFT_RST</name>
+					<description>USB0 Software Reset Register</description>
+					<addressOffset>0x007F</addressOffset>
+					<size>8</size>
+				</register>
+
+				<register>
+					<name>EP0_TXMAXP</name>
+					<description>USB0 EPn Transmit Maximum Packet Length Register</description>
+					<addressOffset>0x0100</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP1_TXMAXP</name>
+					<description>USB0 EPn Transmit Maximum Packet Length Register</description>
+					<addressOffset>0x0110</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP2_TXMAXP</name>
+					<description>USB0 EPn Transmit Maximum Packet Length Register</description>
+					<addressOffset>0x0120</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP3_TXMAXP</name>
+					<description>USB0 EPn Transmit Maximum Packet Length Register</description>
+					<addressOffset>0x0130</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP0_TXCSR_P</name>
+					<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
+					<addressOffset>0x0102</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP1_TXCSR_P</name>
+					<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
+					<addressOffset>0x0112</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP2_TXCSR_P</name>
+					<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
+					<addressOffset>0x0122</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP3_TXCSR_P</name>
+					<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
+					<addressOffset>0x0132</addressOffset>
+					<size>16</size>
+				</register>
+<!--
+				<register>
+					<name>EP0_CSR0_P</name>
+					<description>USB0 EP0 Configuration and Status (Peripheral) Register</description>
+					<addressOffset>0x0102</addressOffset>
+					<size>16</size>
+				</register>
+-->
+<!--
+				<register>
+					<name>EP0_CSR0_H</name>
+					<description>USB0 EP0 Configuration and Status (Host) Register</description>
+					<addressOffset>0x0102</addressOffset>
+					<size>16</size>
+				</register>
+-->
+<!--
+				<register>
+					<name>EP0_TXCSR_H</name>
+					<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
+					<addressOffset>0x0102</addressOffset>
+					<size>16</size>
+				</register>
+-->
+<!--
+				<register>
+					<name>EP1_TXCSR_H</name>
+					<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
+					<addressOffset>0x0112</addressOffset>
+					<size>16</size>
+				</register>
+-->
+<!--
+				<register>
+					<name>EP2_TXCSR_H</name>
+					<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
+					<addressOffset>0x0122</addressOffset>
+					<size>16</size>
+				</register>
+-->
+<!--
+				<register>
+					<name>EP3_TXCSR_H</name>
+					<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
+					<addressOffset>0x0132</addressOffset>
+					<size>16</size>
+				</register>
+-->
+
+				<register>
+					<name>EP0_RXMAXP</name>
+					<description>USB0 EPn Receive Maximum Packet Length Register</description>
+					<addressOffset>0x0104</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP1_RXMAXP</name>
+					<description>USB0 EPn Receive Maximum Packet Length Register</description>
+					<addressOffset>0x0114</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP2_RXMAXP</name>
+					<description>USB0 EPn Receive Maximum Packet Length Register</description>
+					<addressOffset>0x0124</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP3_RXMAXP</name>
+					<description>USB0 EPn Receive Maximum Packet Length Register</description>
+					<addressOffset>0x0134</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP0_RXCSR_P</name>
+					<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
+					<addressOffset>0x0106</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP1_RXCSR_P</name>
+					<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
+					<addressOffset>0x0116</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP2_RXCSR_P</name>
+					<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
+					<addressOffset>0x0126</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP3_RXCSR_P</name>
+					<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
+					<addressOffset>0x0136</addressOffset>
+					<size>16</size>
+				</register>
+<!--
+				<register>
+					<name>EP0_RXCSR_H</name>
+					<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
+					<addressOffset>0x0106</addressOffset>
+					<size>16</size>
+				</register>
+-->
+<!--
+				<register>
+					<name>EP1_RXCSR_H</name>
+					<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
+					<addressOffset>0x0116</addressOffset>
+					<size>16</size>
+				</register>
+-->
+<!--
+				<register>
+					<name>EP2_RXCSR_H</name>
+					<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
+					<addressOffset>0x0126</addressOffset>
+					<size>16</size>
+				</register>
+-->
+<!--
+				<register>
+					<name>EP3_RXCSR_H</name>
+					<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
+					<addressOffset>0x0136</addressOffset>
+					<size>16</size>
+				</register>
+-->
+				<register>
+					<name>EP0_CNT0</name>
+					<description>USB0 EP0 Number of Received Bytes Register</description>
+					<addressOffset>0x0108</addressOffset>
+					<size>16</size>
+				</register>
+<!--
+				<register>
+					<name>EP0_RXCNT</name>
+					<description>USB0 EPn Number of Bytes Received Register</description>
+					<addressOffset>0x0108</addressOffset>
+					<size>16</size>
+				</register>
+-->
+				<register>
+					<name>EP1_RXCNT</name>
+					<description>USB0 EPn Number of Bytes Received Register</description>
+					<addressOffset>0x0118</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP2_RXCNT</name>
+					<description>USB0 EPn Number of Bytes Received Register</description>
+					<addressOffset>0x0128</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP3_RXCNT</name>
+					<description>USB0 EPn Number of Bytes Received Register</description>
+					<addressOffset>0x0138</addressOffset>
+					<size>16</size>
+				</register>
+<!--
+				<register>
+					<name>EP0_FIFOSIZE</name>
+					<description>USB0 FIFO size</description>
+					<addressOffset>0x010F</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP1_FIFOSIZE</name>
+					<description>USB0 FIFO size</description>
+					<addressOffset>0x011F</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP2_FIFOSIZE</name>
+					<description>USB0 FIFO size</description>
+					<addressOffset>0x012F</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>EP3_FIFOSIZE</name>
+					<description>USB0 FIFO size</description>
+					<addressOffset>0x013F</addressOffset>
+					<size>16</size>
+				</register>
+-->
+<!--
+				<register>
+					<name>EP0_CFGDATA0</name>
+					<description>USB0 EP0 Configuration Information Register</description>
+					<addressOffset>0x010F</addressOffset>
+					<size>16</size>
+				</register>
+-->
+				<register>
+					<name>DMA_IRQ</name>
+					<description>USB0 DMA Interrupt Register</description>
+					<addressOffset>0x0200</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>DMA0_CTL</name>
+					<description>USB0 DMA Channel n Control Register</description>
+					<addressOffset>0x0204</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>DMA1_CTL</name>
+					<description>USB0 DMA Channel n Control Register</description>
+					<addressOffset>0x0214</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>DMA0_ADDR</name>
+					<description>USB0 DMA Channel n Address Register</description>
+					<addressOffset>0x0208</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>DMA1_ADDR</name>
+					<description>USB0 DMA Channel n Address Register</description>
+					<addressOffset>0x0218</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>DMA0_CNT</name>
+					<description>USB0 DMA Channel n Count Register</description>
+					<addressOffset>0x020C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>DMA1_CNT</name>
+					<description>USB0 DMA Channel n Count Register</description>
+					<addressOffset>0x021C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>RXDPKTBUFDIS</name>
+					<description>USB0 RX Double Packet Buffer Disable for Endpoints 1 to 3</description>
+					<addressOffset>0x0340</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>TXDPKTBUFDIS</name>
+					<description>USB0 TX Double Packet Buffer Disable for Endpoints 1 to 3</description>
+					<addressOffset>0x0342</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>CT_UCH</name>
+					<description>USB0 Chirp Timeout Register</description>
+					<addressOffset>0x0344</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LPM_ATTR</name>
+					<description>USB0 LPM Attribute Register</description>
+					<addressOffset>0x0360</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>LPM_CTL</name>
+					<description>USB0 LPM Control Register</description>
+					<addressOffset>0x0362</addressOffset>
+					<size>8</size>
+				</register>
+
+				<register>
+					<name>LPM_IEN</name>
+					<description>USB0 LPM Interrupt Enable Register</description>
+					<addressOffset>0x0363</addressOffset>
+					<size>8</size>
+				</register>
+
+				<register>
+					<name>LPM_IRQ</name>
+					<description>USB0 LPM Interrupt Status Register</description>
+					<addressOffset>0x0364</addressOffset>
+					<size>8</size>
+				</register>
+
+				<register>
+					<name>PHY_CTL</name>
+					<description>USB0 FS PHY Control</description>
+					<addressOffset>0x039C</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>PHY_STAT</name>
+					<description>USB0 FS PHY Status</description>
+					<addressOffset>0x039E</addressOffset>
+					<size>16</size>
+				</register>
+
+				<register>
+					<name>RAM_ADDR</name>
+					<description>USB0 RAM Address Register</description>
+					<addressOffset>0x03B0</addressOffset>
+					<size>32</size>
+				</register>
+
+				<register>
+					<name>RAM_DATA</name>
+					<description>USB0 RAM Data Register</description>
+					<addressOffset>0x03B4</addressOffset>
+					<size>32</size>
+				</register>
+			</registers>
+		</peripheral>
+
+    </peripherals>
 </device>

--- a/ADuCM350.svd
+++ b/ADuCM350.svd
@@ -99,7 +99,7 @@ In the event that Third Party Software has only been provided to you in object c
 	
 	
 		<peripheral>
-			<name>ADI_GPT0</name>
+			<name>GPT0</name>
 			<description>General Purpose Timer 0</description>
 			<groupName>GP Timers</groupName>
 			<baseAddress>0x40000000</baseAddress>
@@ -113,24 +113,24 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>TIMER0</name>
 				<value>11</value>
 			</interrupt>
+			<size>16</size>
+			<access>read-write</access>
 			<registers>	
 				<register>
-					<name>LOAD</name>
+					<name>GPTLD</name>
 					<description>16-bit load value</description>
-					<addressOffset>0x00</addressOffset>
-					<size>16</size>						
+					<addressOffset>0x00</addressOffset>				
 				</register>
 				<register>
-					<name>CURCNT</name>
+					<name>GPTVAL</name>
 					<description>16-bit timer value. read only.</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>					
+					<access>read-only</access>					
 				</register>
 				<register>
-					<name>CTL</name>
+					<name>GPTCON</name>
 					<description>Control Register</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>EVENTEN</name>
@@ -365,10 +365,9 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>CLRINT</name>
+					<name>GPTCLRI</name>
 					<description>Clear interrupt register</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>CAP</name>
@@ -404,28 +403,27 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>CAPTURE</name>
+					<name>GPTCAP</name>
 					<description>Capture Register</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>			
-				</register>
+					<access>read-only</access>	
+					</register>
 				<register>
-					<name>ALOAD</name>
+					<name>GPTALD</name>
 					<description>16-bit load value, asynchronous</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
 				</register>
 				<register>
-					<name>ACURCNT</name>
+					<name>GPTAVAL</name>
 					<description>16-bit timer value, asynchronous</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
+					<access>read-only</access>				
 				</register>
 				<register>
-					<name>STATUS</name>
+					<name>GPTSTA</name>
 					<description>Status</description>
 					<addressOffset>0x1C</addressOffset>
-					<size>16</size>				
+					<access>read-only</access>						
 					<fields>
 						<field>
 							<name>PDOK</name>
@@ -502,10 +500,9 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>PWMCTL</name>
+					<name>GPTPCON</name>
 					<description>PWM Control Register</description>
 					<addressOffset>0x20</addressOffset>
-					<size>16</size>  
 					<fields>
 						<field>
 							<name>IDLE_STATE</name>
@@ -546,21 +543,34 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>PWMMATCH</name>
+					<name>GPTPMAT</name>
 					<description>PWM Match Value</description>
 					<addressOffset>0x24</addressOffset>
-					<size>16</size>
 				</register>
 			</registers>
 		</peripheral>
 	<!--
-		<peripheral derived from ADI_GPT0>
-			<name>Test_GPT</name>
-			<baseAddress>0x80000000</baseAddress>
+		<peripheral derivedFrom=GPT0>
+			<name>GPT1</name>
+			<baseAddress>0x40000400</baseAddress>
+			<interrupt>
+				<description>Timer 1 Interrupt</description>
+				<name>TIMER1</name>
+				<value>12</value>
+			</interrupt>	
 		</peripheral>
+		<peripheral derivedFrom=GPT0>
+			<name>GPT2</name>
+			<baseAddress>0x40000800</baseAddress>
+			<interrupt>
+				<description>Timer 1 Interrupt</description>
+				<name>TIMER1</name>
+				<value>12</value>
+			</interrupt>	
+		</peripheral>		
 -->		
 		<peripheral>
-			<name>ADI_GPT1</name>
+			<name>GPT1</name>
 			<description>General Purpose Timer1</description>
 			<groupName>Timer1</groupName>
 			<baseAddress>0x40000400</baseAddress>
@@ -574,24 +584,24 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>TIMER1</name>
 				<value>12</value>
 			</interrupt>
-			<registers>	
+			<size>16</size>							
+			<access>read-write</access>				
+			<registers>		
 				<register>
-					<name>LOAD</name>
+					<name>GPTLD</name>
 					<description>16-bit load value</description>
 					<addressOffset>0x00</addressOffset>
-					<size>16</size>						
 				</register>
 				<register>
-					<name>CURCNT</name>
+					<name>GPTVAL</name>
 					<description>16-bit timer value. read only.</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>					
+					<access>read-only</access>
 				</register>
 				<register>
-					<name>CTL</name>
+					<name>GPTCON</name>
 					<description>Control Register</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>EVENTEN</name>
@@ -649,12 +659,12 @@ In the event that Third Party Software has only been provided to you in object c
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>I2S</name>
-									<description>I2S</description>
+									<description>I2S Event</description>
 									<value>6</value>
 								</enumeratedValue>
 								<enumeratedValue>
 									<name>USB</name>
-									<description>USB</description>
+									<description>USB Event</description>
 									<value>7</value>
 								</enumeratedValue>
 								<enumeratedValue>
@@ -770,7 +780,7 @@ In the event that Third Party Software has only been provided to you in object c
 							<bitWidth>1</bitWidth>
 							<enumeratedValues>
 								<enumeratedValue>
-									<description>Timer runs free</description>																	<description>Enable</description>	<description>Enable</description>	
+									<description>Timer runs free</description>
 									<name>FREERUN</name>
 									<value>0</value>
 								</enumeratedValue>
@@ -830,10 +840,9 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>CLRINT</name>
+					<name>GPTCLRI</name>
 					<description>Clear interrupt register</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>CAP</name>
@@ -869,28 +878,27 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>CAPTURE</name>
+					<name>GPTCAP</name>
 					<description>Capture Register</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>			
-				</register>
+					<access>read-only</access>	
+					</register>
 				<register>
-					<name>ALOAD</name>
+					<name>GPTALD</name>
 					<description>16-bit load value, asynchronous</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
 				</register>
 				<register>
-					<name>ACURCNT</name>
+					<name>GPTAVAL</name>
 					<description>16-bit timer value, asynchronous</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
+					<access>read-only</access>					
 				</register>
 				<register>
-					<name>STATUS</name>
+					<name>GPTSTA</name>
 					<description>Status</description>
 					<addressOffset>0x1C</addressOffset>
-					<size>16</size>				
+					<access>read-only</access>						
 					<fields>
 						<field>
 							<name>PDOK</name>
@@ -967,10 +975,9 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>PWMCTL</name>
+					<name>GPTPCON</name>
 					<description>PWM Control Register</description>
 					<addressOffset>0x20</addressOffset>
-					<size>16</size>  
 					<fields>
 						<field>
 							<name>IDLE_STATE</name>
@@ -1011,15 +1018,14 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>PWMMATCH</name>
+					<name>GPTPMAT</name>
 					<description>PWM Match Value</description>
 					<addressOffset>0x24</addressOffset>
-					<size>16</size>
 				</register>
 			</registers>			
 		</peripheral>
 		<peripheral>
-			<name>ADI_GPT2</name>
+			<name>GPT2</name>
 			<description>General Purpose Timer2 </description>
 			<groupName>T2</groupName>
 			<baseAddress>0x40000800</baseAddress>
@@ -1033,24 +1039,24 @@ In the event that Third Party Software has only been provided to you in object c
 			<description>TIMER 2 interrupt</description>
 			<value>40</value>
 		</interrupt>	
-			<registers>	
+		<size>16</size>						
+		<access>read-write</access>				
+			<registers>
 				<register>
-					<name>LOAD</name>
+					<name>GPTLD</name>
 					<description>16-bit load value</description>
 					<addressOffset>0x00</addressOffset>
-					<size>16</size>						
 				</register>
 				<register>
-					<name>CURCNT</name>
+					<name>GPTVAL</name>
 					<description>16-bit timer value. read only.</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>					
-				</register>
+					<access>read-only</access>	
+					</register>
 				<register>
-					<name>CTL</name>
+					<name>GPTCON</name>
 					<description>Control Register</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>EVENTEN</name>
@@ -1289,10 +1295,9 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>CLRINT</name>
+					<name>GPTCLRI</name>
 					<description>Clear interrupt register</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>CAP</name>
@@ -1328,28 +1333,27 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>CAPTURE</name>
+					<name>GPTCAP</name>
 					<description>Capture Register</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>			
+					<access>read-only</access>				
 				</register>
 				<register>
-					<name>ALOAD</name>
+					<name>GPTALD</name>
 					<description>16-bit load value, asynchronous</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
 				</register>
 				<register>
-					<name>ACURCNT</name>
+					<name>GPTAVAL</name>
 					<description>16-bit timer value, asynchronous</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
+					<access>read-only</access>	
 				</register>
 				<register>
-					<name>STATUS</name>
+					<name>GPTSTA</name>
 					<description>Status</description>
 					<addressOffset>0x1C</addressOffset>
-					<size>16</size>				
+					<access>read-only</access>						
 					<fields>
 						<field>
 							<name>PDOK</name>
@@ -1426,10 +1430,9 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>PWMCTL</name>
+					<name>GPTPCON</name>
 					<description>PWM Control Register</description>
 					<addressOffset>0x20</addressOffset>
-					<size>16</size>  
 					<fields>
 						<field>
 							<name>IDLE_STATE</name>
@@ -1470,16 +1473,15 @@ In the event that Third Party Software has only been provided to you in object c
 					</fields>
 				</register>
 				<register>
-					<name>PWMMATCH</name>
+					<name>GPTPMAT</name>
 					<description>PWM Match Value</description>
 					<addressOffset>0x24</addressOffset>
-					<size>16</size>
 				</register>
 			</registers>
 		</peripheral>
 		<peripheral>
-			<name>ADI_ID</name>
-			<description>ID </description>
+			<name>ID</name>
+			<description>Identification Registers</description>
 			<groupName>PWRCTL</groupName>
 			<baseAddress>0x40002020</baseAddress>
 			<addressBlock>
@@ -1487,23 +1489,23 @@ In the event that Third Party Software has only been provided to you in object c
 				<size>0x8</size>
 				<usage>registers</usage>
 			</addressBlock>
+			<size>16</size>							
+			<access>read-write</access>			
 			<registers>
 				<register>
 					<name>ADIID</name>
 					<description>Analog Devices ID Register</description>
 					<addressOffset>0</addressOffset>
-					<size>16</size>				
 				</register>
 				<register>
 					<name>CHIPID</name>
 					<description>Chip ID Register</description>
 					<addressOffset>4</addressOffset>
-					<size>16</size>				
 				</register>				
 			</registers>
 		</peripheral>			
 		<peripheral>
-		<name>ADI_PWR</name>
+		<name>PWR</name>
 		<description>Power Management Unit</description>
 		<groupName>PWRCTL</groupName>
 		<baseAddress>0x40002400</baseAddress>
@@ -1512,12 +1514,13 @@ In the event that Third Party Software has only been provided to you in object c
 			<size>0x14</size>
 			<usage>registers</usage>
 		</addressBlock>
+			<size>16</size>							
+			<access>read-write</access>			
 		<registers>
 			<register>
 			<name>PWRMOD</name>
 			<description>PWR Power modes</description>
 			<addressOffset>0x00</addressOffset>
-			<size>16</size>
 			<fields>
 				<field>
 			        <name>RAM0_RET</name>
@@ -1589,7 +1592,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>PWRKEY</name>
 			<description>PWR Key protection for PWRMOD</description>
 			<addressOffset>0x04</addressOffset>
-			<size>16</size>
 			<fields>
 				<field>
 					<name>KEY</name>
@@ -1618,7 +1620,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>PSMCON</name>
 			<description>PWR PSM Configuration</description>
 			<addressOffset>0x08</addressOffset>
-			<size>16</size>
 			<fields>
 				<field>
 					<name>VCCMPSMSTAT</name>
@@ -1734,7 +1735,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>OSCKEY</name>
 			<description>PWR Key protection for OSCCTRL</description>
 			<addressOffset>0x0C</addressOffset>
-			<size>16</size>
 			<fields>
 				<field>
 					<name>VALUE</name>
@@ -1759,12 +1759,11 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>OSCCTRL</name>
 			<description>PWR Oscillator control</description>
 			<addressOffset>0x10</addressOffset>
-			<size>16</size>
 		</register>		
 		</registers>
 	</peripheral>
 	<peripheral>
-		<name>ADI_EI</name>
+		<name>EI</name>
 		<description>External Interrupts</description>
 		<groupName>PWRCTL</groupName>
 		<baseAddress>0x40002420</baseAddress>
@@ -1818,12 +1817,13 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>EINT8</name>
 				<value>9</value>
 			</interrupt>
+			<size>16</size>
+			<access>read-write</access>				
 			<registers>		
 		<register>
 			<name>EI0CFG</name>
 			<description>PWR External Interrupt configuration 0</description>
 			<addressOffset>0x0</addressOffset>
-			<size>16</size>
 			<fields>
 				<field>
 					<name>IRQ3EN</name>
@@ -1946,7 +1946,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>EI1CFG</name>
 			<description>PWR External Interrupt configuration 1</description>
 			<addressOffset>0x4</addressOffset>
-			<size>16</size>
             <fields>
                 <field>
                     <name>IRQ7EN</name>
@@ -2051,7 +2050,6 @@ In the event that Third Party Software has only been provided to you in object c
             <name>EI2CFG</name>
 			<description>PWR External Interrupt configuration 2</description>
 			<addressOffset>0x8</addressOffset>
-			<size>16</size>
             <fields>
                 <field>
                     <name>USBVBUSEN</name>
@@ -2156,7 +2154,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>EICLR</name>
 			<description>PWR External Interrupt clear</description>
 			<addressOffset>0x10</addressOffset>
-			<size>16</size>
             <fields>
                 <field>
                     <name>USBVBUS</name>
@@ -2321,7 +2318,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>NMICLR</name>
 			<description>PWR Non-maskable interrupt clear</description>
 			<addressOffset>0x14</addressOffset>
-			<size>16</size>
             <fields>
                 <field>
                     <name>CLEAR</name>
@@ -2343,7 +2339,7 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>USBWKSTAT</name>
 			<description>PWR USB Wakeup Status</description>
 			<addressOffset>0x18</addressOffset>
-			<size>16</size>
+			<access>read-only</access>
             <fields>
                 <field>
                     <name>USBVBUS</name>
@@ -2370,7 +2366,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>RSTSTA</name>
 			<description>PWR Reset status</description>
 			<addressOffset>0x20</addressOffset>
-			<size>16</size>
             <fields>
                 <field>
                     <name>SWRST</name>
@@ -2401,7 +2396,7 @@ In the event that Third Party Software has only been provided to you in object c
 		</registers>
 	</peripheral>
 	<peripheral>
-		<name>ADI_PWRVCC</name>
+		<name>PWRVCC</name>
 		<description>Power</description>
 		<groupName>PWRCTL</groupName>
 		<baseAddress>0x40002480</baseAddress>
@@ -2410,13 +2405,14 @@ In the event that Third Party Software has only been provided to you in object c
 			<size>0x10</size>
 			<usage>registers</usage>
 		</addressBlock>
+		<size>16</size>						
+		<access>read-write</access>			
 		<registers>		
 
 		<register>
 			<name>VCCMCON</name>
 			<description>PWR VCCM Control and Status</description>
 			<addressOffset>0x8</addressOffset>
-			<size>16</size>
             <fields>
                 <field>
                     <name>VCCMTHR_HYST</name>
@@ -2449,7 +2445,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>VBACKCON</name>
 			<description>PWR VBACK control and status</description>
 			<addressOffset>0xC</addressOffset>
-			<size>16</size>
             <fields>
                 <field>
                     <name>VBACKTRIP</name>
@@ -2480,11 +2475,11 @@ In the event that Third Party Software has only been provided to you in object c
 	</registers>
 </peripheral>
 		<peripheral>
-			<name>ADI_WUT</name>
+			<name>WUT</name>
 			<description>Wake-up timer</description>
 			<groupName>WUT</groupName>
 			<baseAddress>0x40002500</baseAddress>
-			<size>16</size>
+			
 
 			<addressBlock>
 				<offset>0</offset>
@@ -2497,27 +2492,29 @@ In the event that Third Party Software has only been provided to you in object c
 				<description>Wake Up Timer interrupt</description>
 				<value>0</value>
 			</interrupt>
+
+			<size>16</size>							
+			<access>read-write</access>	
 			
 			<registers>
 				<register>
 					<name>T2VAL0</name>
 					<description>WUT Current count value - LS halfword.</description>
 					<addressOffset>0x00</addressOffset>
-					<size>16</size>
+					<access>read-only</access>	
 				</register>
 
 				<register>
 					<name>T2VAL1</name>
 					<description>WUT Current count value - MS halfword</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>
+					<access>read-only</access>	
 				</register>
 
 				<register>
 					<name>T2CON</name>
 					<description>WUT Control</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>STOP</name>
@@ -2607,7 +2604,6 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>T2INC</name>
 					<description>WUT 12-bit interval for wakeup field A</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>INTERVAL</name>
@@ -2622,28 +2618,24 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>T2WUFB0</name>
 					<description>WUT Wakeup field B - LS halfword</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>
 				</register>
 
 				<register>
 					<name>T2WUFB1</name>
 					<description>WUT Wakeup field B - MS halfword</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
 				</register>
 
 				<register>
 					<name>T2WUFC0</name>
 					<description>WUT Wakeup field C - LS halfword</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
 				</register>
 
 				<register>
 					<name>T2WUFC1</name>
 					<description>WUT Wakeup field C - MS halfword</description>
 					<addressOffset>0x1C</addressOffset>
-					<size>16</size>
 				</register>
 
 				<register>
@@ -2656,14 +2648,12 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>T2WUFD1</name>
 					<description>WUT Wakeup field D - MS halfword</description>
 					<addressOffset>0x24</addressOffset>
-					<size>16</size>
 				</register>
 
 				<register>
 					<name>T2IEN</name>
 					<description>WUT Interrupt enable</description>
 					<addressOffset>0x28</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>ROLL</name>
@@ -2702,7 +2692,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>T2STA</name>
 					<description>WUT Status</description>
 					<addressOffset>0x2C</addressOffset>
-					<size>16</size>
+					<access>read-only</access>	
 					<fields>
 						<field>
 							<name>PDOK</name>
@@ -2759,7 +2749,6 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>T2CLRI</name>
 					<description>WUT Clear interrupt register</description>
 					<addressOffset>0x30</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>ROLL</name>
@@ -2798,37 +2787,35 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>WUTVAL_LOW</name>
 					<description>WUT Unsynchronized lower 16 bits of WU Timer counter value.</description>
 					<addressOffset>0x34</addressOffset>
-					<size>16</size>
 				</register>		
 
 				<register>
 					<name>WUTVAL_HIGH</name>
 					<description>WUT Unsynchronized upper 16 bits of WU Timer counter value.</description>
 					<addressOffset>0x38</addressOffset>
-					<size>16</size>
 				</register>
 
 				<register>
 					<name>T2WUFA0</name>
 					<description>WUT Wakeup field A - LS halfword</description>
 					<addressOffset>0x3C</addressOffset>
-					<size>16</size>
+					<access>read-only</access>						
 				</register>
 
 				<register>
 					<name>T2WUFA1</name>
 					<description>WUT Wakeup field A - MS halfword</description>
 					<addressOffset>0x40</addressOffset>
-					<size>16</size>
+					<access>read-only</access>						
 				</register>
 			</registers>
 		</peripheral>
 		<peripheral>
-			<name>ADI_WDT</name>
+			<name>WDT</name>
 			<description>WatchDog Timer</description>
 			<groupName>WDT</groupName>
 			<baseAddress>0x40002580</baseAddress>
-			<size>16</size>
+			
 
 			<addressBlock>
 				<offset>0</offset>
@@ -2841,28 +2828,26 @@ In the event that Third Party Software has only been provided to you in object c
 				<description>WDT Interrupt</description>
 				<value>10</value>
 			</interrupt>
-
+			<size>16</size>							
+			<access>read-write</access>	
 			<registers>
 
 				<register>
 					<name>T3LD</name>
 					<description>WDT Load value</description>
 					<addressOffset>0x00</addressOffset>
-					<size>16</size>
 				</register>
 
 				<register>
 					<name>T3VAL</name>
 					<description>WDT Current count value</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>
 				</register>
 
 			<register>
 				<name>T3CON</name>
 				<description>WDT Control</description>
 				<addressOffset>0x08</addressOffset>
-				<size>16</size>
 					<fields>
 						<field>
 							<name>MOD</name>
@@ -2923,14 +2908,16 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>T3CLRI</name>
 					<description>WDT Clear interrupt register</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
 				</register>
-
+				<register>
+					<name>T3VALA</name>
+					<description>WDT Asynchronous Count</description>
+					<addressOffset>0x14</addressOffset>
+				</register>
 				<register>
 					<name>T3STA</name>
 					<description>WDT Status</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
 					<fields>
 						<field>
 							<name>LOCK</name>
@@ -2968,7 +2955,7 @@ In the event that Third Party Software has only been provided to you in object c
 		</peripheral>
 		
 		<peripheral>
-		<name>ADI_RTC</name>
+		<name>RTC</name>
 		<description>RealTimeClock</description>
 	<groupName>RTC</groupName>
 	<baseAddress>0x40002600</baseAddress>
@@ -2985,13 +2972,14 @@ In the event that Third Party Software has only been provided to you in object c
 		<description>Real Time Clock interrupt</description>
 		<value>43</value>
 	</interrupt>
+	<size>16</size>						
+	<access>read-write</access>		
     <registers>
 
 	<register>
 		<name>RTCCR</name>
 		<description>RTC RTC Control</description>
 		<addressOffset>0x00</addressOffset>
-		<size>16</size>
             <fields>
                 <field>
                     <name>WPENDINTEN</name>
@@ -3066,7 +3054,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>RTCSR0</name>
 			<description>RTC RTC Status 0</description>
 			<addressOffset>0x04</addressOffset>
-			<size>16</size>
             <fields>
                 <field>
                     <name>WSYNCTRM</name>
@@ -3159,7 +3146,6 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>RTCSR1</name>
 			<description>RTC RTC Status 1</description>
 			<addressOffset>0x08</addressOffset>
-			<size>16</size>
             <fields>
                 <field>
                     <name>WPENDTRM</name>
@@ -3216,35 +3202,30 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>RTCCNT0</name>
 			<description>RTC RTC Count 0</description>
 			<addressOffset>0x0C</addressOffset>
-			<size>16</size>
 		</register>
 
 		<register>
 			<name>RTCCNT1</name>
 			<description>RTC RTC Count 1</description>
 			<addressOffset>0x10</addressOffset>
-			<size>16</size>
 		</register>
 
 		<register>
 			<name>RTCALM0</name>
 			<description>RTC RTC Alarm 0</description>
 			<addressOffset>0x14</addressOffset>
-			<size>16</size>
 		</register>
 
 		<register>
 			<name>RTCALM1</name>
 			<description>RTC RTC Alarm 1</description>
 			<addressOffset>0x18</addressOffset>
-			<size>16</size>
 		</register>
 
 		<register>
 			<name>RTCTRM</name>
 			<description>RTC RTC Trim</description>
 			<addressOffset>0x1C</addressOffset>
-			<size>16</size>
 			<fields>
                 <field>
                     <name>TRMIVL</name>
@@ -3271,12 +3252,11 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>RTCGWY</name>
 			<description>RTC RTC Gateway</description>
 			<addressOffset>0x20</addressOffset>
-			<size>16</size>
 		</register>
 		</registers>
 	</peripheral>
 		<peripheral>
-			<name>ADI_I2C</name>
+			<name>I2C</name>
 			
 			<description>I2C Master/Slave</description>
 			<groupName>I2C</groupName>
@@ -3298,14 +3278,16 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>I2CM</name>
 				<description>I2C 0 master interrupt</description>
 				<value>18</value>
-			</interrupt>			
+			</interrupt>
+			<size>16</size>
+			<access>read-write</access>
 			<registers>
 
 				<register>
 					<name>I2CMCON</name>
 					<description>I2C Master control</description>
 					<addressOffset>0x00</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>PRESTOP</name>
@@ -3398,7 +3380,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CMSTA</name>
 					<description>I2C Master status</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>SCL</name>
@@ -3491,7 +3473,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CMRX</name>
 					<description>I2C Master receive data</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>I2CMRX</name>
@@ -3506,7 +3488,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CMTX</name>
 					<description>I2C Master transmit data</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>I2CMTX</name>
@@ -3521,7 +3503,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CMRXCNT</name>
 					<description>I2C Master receive data count</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>EXTEND</name>
@@ -3542,7 +3524,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CMCRXCNT</name>
 					<description>I2C Master current receive data count</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>COUNT</name>
@@ -3557,7 +3539,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CADR1</name>
 					<description>I2C 1st master address byte</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>ADR1</name>
@@ -3572,7 +3554,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CADR2</name>
 					<description>I2C 2nd master address byte</description>
 					<addressOffset>0x1C</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>ADR2</name>
@@ -3586,7 +3568,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CBYT</name>
 					<description>I2C Start byte</description>
 					<addressOffset>0x20</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>SBYTE</name>
@@ -3601,7 +3583,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CDIV</name>
 					<description>I2C Serial clock period divisor</description>
 					<addressOffset>0x24</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>HIGH</name>
@@ -3622,7 +3604,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CSCON</name>
 					<description>I2C Slave control</description>
 					<addressOffset>0x28</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>STXDMA</name>
@@ -3721,7 +3703,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CSSTA</name>
 					<description>I2C Slave I2C Status/Error/IRQ</description>
 					<addressOffset>0x2C</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>START</name>
@@ -3808,7 +3790,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CSRX</name>
 					<description>I2C Slave receive</description>
 					<addressOffset>0x30</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>I2CSRX</name>
@@ -3823,7 +3805,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CSTX</name>
 					<description>I2C Slave transmit</description>
 					<addressOffset>0x34</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>I2CSTX</name>
@@ -3838,7 +3820,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CALT</name>
 					<description>I2C Hardware general call ID</description>
 					<addressOffset>0x38</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>ALT</name>
@@ -3853,7 +3835,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CID0</name>
 					<description>I2C 1st slave address device ID</description>
 					<addressOffset>0x3C</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>ID0</name>
@@ -3868,7 +3850,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CID1</name>
 					<description>I2C 2nd slave address device ID</description>
 					<addressOffset>0x40</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>ID1</name>
@@ -3883,7 +3865,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CID2</name>
 					<description>I2C 3rd slave address device ID</description>
 					<addressOffset>0x44</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>ID2</name>
@@ -3898,7 +3880,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CID3</name>
 					<description>I2C 4th slave address device ID</description>
 					<addressOffset>0x48</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>ID3</name>
@@ -3913,7 +3895,7 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>I2CFSTA</name>
 			<description>I2C Master and slave FIFO status</description>
 			<addressOffset>0x4C</addressOffset>
-			<size>16</size>
+			
             <fields>
                 <field>
                     <name>MFLUSH</name>
@@ -3958,7 +3940,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CSHCON</name>
 					<description>I2C Shared control</description>
 					<addressOffset>0x50</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>RESET</name>
@@ -3973,7 +3955,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CTCTL</name>
 					<description>I2C Timing Control Register</description>
 					<addressOffset>0x54</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>FILTEROFF</name>
@@ -3993,7 +3975,7 @@ In the event that Third Party Software has only been provided to you in object c
 		</peripheral>
 
 		<peripheral>
-			<name>ADI_SPI0</name>
+			<name>SPI0</name>
 			
 			<description>SPI0 Maste/Slave</description>
 			<groupName>SPI0</groupName>
@@ -4011,7 +3993,8 @@ In the event that Third Party Software has only been provided to you in object c
 				<description>SPI 0 interrupt</description>
 				<value>15</value>
 			</interrupt>
-
+			<size>16</size>
+			<access>read-write</access>
 			<registers>	
 				<register>
 					<name>SPISTA</name>
@@ -4135,7 +4118,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPIRX</name>
 					<description>SPI0 Receive</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>DMA</name>
@@ -4156,7 +4139,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPITX</name>
 					<description>SPI0 Transmit</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>DMA</name>
@@ -4177,7 +4160,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPIDIV</name>
 					<description>SPI0 Baud rate selection</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>CSIRQ</name>
@@ -4210,7 +4193,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPICON</name>
 					<description>SPI0 SPI configuration</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>MOD</name>
@@ -4309,7 +4292,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPIDMA</name>
 					<description>SPI0 SPI DMA enable</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>IENRXDMA</name>
@@ -4372,7 +4355,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPICNT</name>
 					<description>SPI0 Transfer byte count</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>COUNT</name>
@@ -4386,7 +4369,7 @@ In the event that Third Party Software has only been provided to you in object c
 		</peripheral>
 		
 		<peripheral>
-			<name>ADI_SPI1</name>
+			<name>SPI1</name>
 			
 			<description>SPI1 Master/Slave</description>
 			<groupName>SPI1</groupName>
@@ -4404,6 +4387,8 @@ In the event that Third Party Software has only been provided to you in object c
 				<description>interrupt</description>
 				<value>42</value>
 			</interrupt>
+			<size>16</size>
+			<access>read-write</access>			
 			<registers>	
 				<register>
 					<name>SPISTA</name>
@@ -4527,7 +4512,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPIRX</name>
 					<description>SPI1 Receive</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>DMA</name>
@@ -4548,7 +4533,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPITX</name>
 					<description>SPI1 Transmit</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>DMA</name>
@@ -4569,7 +4554,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPIDIV</name>
 					<description>SPI1 Baud rate selection</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>CSIRQ</name>
@@ -4602,7 +4587,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPICON</name>
 					<description>SPI1 SPI configuration</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>MOD</name>
@@ -4701,7 +4686,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPIDMA</name>
 					<description>SPI1 SPI DMA enable</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>IENRXDMA</name>
@@ -4764,7 +4749,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPICNT</name>
 					<description>SPI1 Transfer byte count</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>COUNT</name>
@@ -4779,7 +4764,7 @@ In the event that Third Party Software has only been provided to you in object c
 	</peripheral>
 		
 		<peripheral>
-			<name>ADI_UART</name>
+			<name>UART</name>
 			
 			<description>Uart</description>
 			<groupName>UART</groupName>
@@ -4797,6 +4782,8 @@ In the event that Third Party Software has only been provided to you in object c
 				<description>interrupt</description>
 				<value>14</value>
 			</interrupt>
+			<size>16</size>
+			<access>read-write</access>			
 			<registers>
 
 			<register>
@@ -4831,7 +4818,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>COMIEN</name>
 				<description>UART Interrupt Enable</description>
 				<addressOffset>0x04</addressOffset>
-				<size>16</size>
+				
 				<fields>
 					<field>
 						<name>EDMAR</name>
@@ -4876,7 +4863,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>COMIIR</name>
 				<description>UART Interrupt ID</description>
 				<addressOffset>0x08</addressOffset>
-				<size>16</size>
+				
 				<fields>
 					<field>
 						<name>STA</name>
@@ -4897,7 +4884,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>COMLCR</name>
 				<description>UART Line Control</description>
 				<addressOffset>0x0C</addressOffset>
-				<size>16</size>
+				
 				<fields>
 					<field>
 						<name>BRK</name>
@@ -4942,7 +4929,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>COMMCR</name>
 				<description>UART Modem Control</description>
 				<addressOffset>0x10</addressOffset>
-				<size>16</size>
+				
 				<fields>
 					<field>
 						<name>LOOPBACK</name>
@@ -4981,7 +4968,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>COMLSR</name>
 				<description>UART Line Status</description>
 				<addressOffset>0x14</addressOffset>
-				<size>16</size>
+				
 				<fields>
 					<field>
 						<name>TEMT</name>
@@ -5032,7 +5019,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>COMMSR</name>
 				<description>UART Modem Status</description>
 				<addressOffset>0x18</addressOffset>
-				<size>16</size>
+				
 				<fields>
 					<field>
 						<name>DCD</name>
@@ -5089,7 +5076,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>COMSCR</name>
 				<description>UART Scratch buffer</description>
 				<addressOffset>0x1C</addressOffset>
-				<size>16</size>
+				
 				<fields>
 					<field>
 						<name>SCR</name>
@@ -5103,7 +5090,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>COMFBR</name>
 				<description>UART Fractional Baud Rate</description>
 				<addressOffset>0x24</addressOffset>
-				<size>16</size>
+				
                 <fields>
                     <field>
                         <name>FBEN</name>
@@ -5130,13 +5117,13 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>COMDIV</name>
 				<description>UART Baudrate divider</description>
 				<addressOffset>0x28</addressOffset>
-				<size>16</size>
+				
 			</register>
 		</registers>
 	</peripheral>
 
 	<peripheral>
-		<name>ADI_I2S</name>
+		<name>I2S</name>
 		
 		<description>I2S Master/Slave</description>
 		<groupName>I2S</groupName>
@@ -5154,13 +5141,15 @@ In the event that Third Party Software has only been provided to you in object c
 			<description>I2S interrupt</description>
 			<value>39</value>
 		</interrupt>
+		<size>16</size>
+		<access>read-write</access>		
 		<registers>
 
 			<register>
 				<name>OUT1L</name>
 				<description>I2S Channel 1 LSBs</description>
 				<addressOffset>0x00</addressOffset>
-				<size>16</size>
+				
 				<fields>
 						<field>
 							<description>I2S Ch1 lsb</description>
@@ -5175,7 +5164,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>OUT1H</name>
 				<description>I2S Channel 1 MSBs</description>
 				<addressOffset>0x04</addressOffset>
-				<size>16</size>
+				
 				<fields>
 						<field>
 							<description>I2S Ch1 msb</description>
@@ -5190,7 +5179,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>OUT2L</name>
 				<description>I2S Channel 2 LSBs</description>
 				<addressOffset>0x08</addressOffset>
-				<size>16</size>
+				
 				<fields>
 						<field>
 							<description>I2S Ch2 lsb</description>
@@ -5204,7 +5193,7 @@ In the event that Third Party Software has only been provided to you in object c
 				<name>OUT2H</name>
 				<description>I2S Channel 2 MSBs</description>
 				<addressOffset>0x0C</addressOffset>
-				<size>16</size>
+				
 				<fields>
 						<field>
 							<description>I2S Ch2 msb</description>
@@ -5219,42 +5208,41 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>MODE1</name>
 					<description>I2S I2S format modes 1</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>MODE2</name>
 					<description>I2S I2S format modes 2</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>CFG1</name>
 					<description>I2S I2S configuration 1</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>CFG2</name>
 					<description>I2S I2S configuration 2</description>
 					<addressOffset>0x1C</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>STAT</name>
 					<description>I2S I2S status</description>
 					<addressOffset>0x20</addressOffset>
-					<size>16</size>
+					
 				</register>
 			</registers>
 	</peripheral>
 	
 		<peripheral>
-			<name>ADI_BEEP</name>
-			
+			<name>BEEP</name>			
 			<description>Beeper</description>
 			<groupName>BEEP</groupName>
 			<baseAddress>0x40005C00</baseAddress>
@@ -5271,40 +5259,42 @@ In the event that Third Party Software has only been provided to you in object c
 				<description>Beep interrupt</description>
 				<value>45</value>
 			</interrupt>
+			<size>16</size>
+			<access>read-write</access>			
 			<registers>
 
 				<register>
-					<name>BEEP_CFG</name>
+					<name>CFG</name>
 					<description>BEEP Beeper configuration</description>
 					<addressOffset>0x00</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>STAT</name>
 					<description>BEEP Beeper status</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>TONE_A</name>
 					<description>BEEP Tone A Data</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>TONE_B</name>
 					<description>BEEP Tone B Data</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
+					
 				</register>
 			</registers>
 	</peripheral>
 	
 		<peripheral>
-			<name>ADI_RNG</name>
+			<name>RNG</name>
 			
 			<description>Random Bit Generator</description>
 			<groupName>RBG</groupName>
@@ -5322,13 +5312,15 @@ In the event that Third Party Software has only been provided to you in object c
 				<description>Random Bit Generator interrupt</description>
 				<value>58</value>
 			</interrupt>
+			<size>16</size>
+			<access>read-write</access>			
 			<registers>
 
 				<register>
 					<name>RNGCTL</name>
 					<description>RNG RNG Control Register</description>
 					<addressOffset>0x00</addressOffset>
-					<size>16</size>
+					
 					<fields>
                     <field>
                         <name>TMRMODE</name>
@@ -5355,7 +5347,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>RNGLEN</name>
 					<description>RNG RNG Sample Length Register</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>
+					
 					<fields>
                     <field>
                         <name>LENPRE</name>
@@ -5376,7 +5368,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>RNGSTAT</name>
 					<description>RNG RNG Status Register</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
+					
 					<fields>
                     <field>
                         <name>RNGRDY</name>
@@ -5391,14 +5383,14 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>RNGDATA</name>
 					<description>RNG RNG Data Register</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>RNGCNTL</name>
 					<description>RNG Oscillator Count Low</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>
+					
 					<access>read-only</access>					
 				</register>
 
@@ -5406,7 +5398,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>RNGCNTH</name>
 					<description>RNG Oscillator Count High</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
+					
 					<access>read-only</access>					
 					<fields>
                     <field>
@@ -5421,9 +5413,9 @@ In the event that Third Party Software has only been provided to you in object c
 		</peripheral>
 	
 		<peripheral>
-			<name>ADI_LCD</name>
+			<name>LCD</name>
 			<description>LCD Controller</description>
-			<groupName>LCD</groupName>
+			<groupName>LCD Controller</groupName>
 			<baseAddress>0x40008000</baseAddress>
 			<size>32</size>
 
@@ -5438,13 +5430,15 @@ In the event that Third Party Software has only been provided to you in object c
 				<description>LCD Controller interrupt</description>
 				<value>46</value>
 			</interrupt>
+			<size>16</size>
+			<access>read-write</access>
 			<registers>
 
 				<register>
 					<name>LCDCON</name>
 					<description>LCD LCD Configuration Register</description>
 					<addressOffset>0x00</addressOffset>
-					<size>16</size>
+					
                 <fields>
                     <field>
                         <name>BLINKEN</name>
@@ -5507,7 +5501,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>LCDSTAT</name>
 					<description>LCD LCD Status Register</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>
+					
 					<fields>
                     <field>
                         <name>LCD</name>
@@ -5546,7 +5540,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>LCDBLINK</name>
 					<description>LCD LCD Blink Control Register</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
+					
 					<fields>
                     <field>
                         <name>AUTOSWITCH</name>
@@ -5573,7 +5567,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>LCDCONTRAST</name>
 					<description>LCD LCD Contrast Control Register</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
+					
 					<fields>
                     <field>
                         <name>CP_PD</name>
@@ -5612,119 +5606,119 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>LCDDATA0_S0</name>
 					<description>LCD Screen 0 LCD Data Register n</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA1_S0</name>
 					<description>LCD Screen 0 LCD Data Register n</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA2_S0</name>
 					<description>LCD Screen 0 LCD Data Register n</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA3_S0</name>
 					<description>LCD Screen 0 LCD Data Register n</description>
 					<addressOffset>0x1C</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA4_S0</name>
 					<description>LCD Screen 0 LCD Data Register n</description>
 					<addressOffset>0x20</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA5_S0</name>
 					<description>LCD Screen 0 LCD Data Register n</description>
 					<addressOffset>0x24</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA6_S0</name>
 					<description>LCD Screen 0 LCD Data Register n</description>
 					<addressOffset>0x28</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA7_S0</name>
 					<description>LCD Screen 0 LCD Data Register n</description>
 					<addressOffset>0x2C</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA0_S1</name>
 					<description>LCD Screen 1 LCD Data Register n</description>
 					<addressOffset>0x30</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA1_S1</name>
 					<description>LCD Screen 1 LCD Data Register n</description>
 					<addressOffset>0x34</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA2_S1</name>
 					<description>LCD Screen 1 LCD Data Register n</description>
 					<addressOffset>0x38</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA3_S1</name>
 					<description>LCD Screen 1 LCD Data Register n</description>
 					<addressOffset>0x3C</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA4_S1</name>
 					<description>LCD Screen 1 LCD Data Register n</description>
 					<addressOffset>0x40</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA5_S1</name>
 					<description>LCD Screen 1 LCD Data Register n</description>
 					<addressOffset>0x44</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA6_S1</name>
 					<description>LCD Screen 1 LCD Data Register n</description>
 					<addressOffset>0x48</addressOffset>
-					<size>16</size>
+					
 				</register>
 
 				<register>
 					<name>LCDDATA7_S1</name>
 					<description>LCD Screen 1 LCD Data Register n</description>
 					<addressOffset>0x4C</addressOffset>
-					<size>16</size>
+					
 				</register>
 			</registers>
 		</peripheral>
 		
 	<peripheral>
-		<name>ADI_DMA</name>
-		<description>DMA</description>
+		<name>DMA</name>
+		<description>DMA Controller</description>
 		<groupName>DMAC</groupName>
 		<baseAddress>0x40010000</baseAddress>
 		<size>32</size>
@@ -5819,13 +5813,16 @@ In the event that Third Party Software has only been provided to you in object c
 			<name>DMA_I2S</name>
 			<description>DMA Ch 15 interrupt</description>
 			<value>35</value>
-		</interrupt>		
+		</interrupt>
+			<size>32</size>
+			<access>read-write</access>		
 		<registers>
 
 	<register>
 		<name>DMASTA</name>
 		<description>DMA DMA Status</description>
 		<addressOffset>0x00</addressOffset>
+		<access>read-only</access>	
 		<fields>
                     <field>
                         <name>CHNLSM1</name>
@@ -5896,21 +5893,20 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAPDBPTR</name>
 		<description>DMA DMA channel primary control data base pointer</description>
 		<addressOffset>0x08</addressOffset>
-		<size>32</size>
 	</register>
 
 	<register>
 		<name>DMAADBPTR</name>
 		<description>DMA DMA channel alternate control data base pointer</description>
 		<addressOffset>0x0C</addressOffset>
-		<size>32</size>
+		<access>read-only</access>			
 	</register>
 
 	<register>
 		<name>DMASWREQ</name>
 		<description>DMA DMA channel software request</description>
 		<addressOffset>0x14</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHSWREQ</name>
@@ -5925,7 +5921,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMARMSKSET</name>
 		<description>DMA DMA channel request mask set</description>
 		<addressOffset>0x20</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHREQMSET</name>
@@ -5940,7 +5936,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMARMSKCLR</name>
 		<description>DMA DMA channel request mask clear</description>
 		<addressOffset>0x24</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHREQMCLR</name>
@@ -5955,7 +5951,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAENSET</name>
 		<description>DMA DMA channel enable set</description>
 		<addressOffset>0x28</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHENSET</name>
@@ -5970,7 +5966,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAENCLR</name>
 		<description>DMA DMA channel enable clear</description>
 		<addressOffset>0x2C</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHENCLR</name>
@@ -5985,7 +5981,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAALTSET</name>
 		<description>DMA DMA channel primary-alternate set</description>
 		<addressOffset>0x30</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHPRIALTSET</name>
@@ -6000,7 +5996,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAALTCLR</name>
 		<description>DMA DMA channel primary-alternate clear</description>
 		<addressOffset>0x34</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHPRIALTCLR</name>
@@ -6015,7 +6011,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAPRISET</name>
 		<description>DMA DMA channel priority set</description>
 		<addressOffset>0x38</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHPRISET</name>
@@ -6030,7 +6026,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAPRICLR</name>
 		<description>DMA DMA channel priority clear</description>
 		<addressOffset>0x3C</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHPRICLR</name>
@@ -6045,7 +6041,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAERRCHNLCLR</name>
 		<description>DMA DMA Per Channel Error Clear</description>
 		<addressOffset>0x48</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHNL</name>
@@ -6060,7 +6056,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAERRCLR</name>
 		<description>DMA DMA bus error clear</description>
 		<addressOffset>0x4C</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>ERRCLR</name>
@@ -6075,7 +6071,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMAINVALIDDESCCLR</name>
 		<description>DMA DMA Per Channel Invalid Descriptor Clear</description>
 		<addressOffset>0x50</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHNL</name>
@@ -6090,7 +6086,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMABSSET</name>
 		<description>DMA DMA channel bytes swap enable set</description>
 		<addressOffset>0x0800</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHBSWAPSET</name>
@@ -6105,7 +6101,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMABSCLR</name>
 		<description>DMA DMA channel bytes swap enable clear</description>
 		<addressOffset>0x0804</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHBSWAPCLR</name>
@@ -6120,7 +6116,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMASRCADSSET</name>
 		<description>DMA DMA channel source address decrement enable set</description>
 		<addressOffset>0x0810</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHSRCADRDECSET</name>
@@ -6135,7 +6131,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMASRCADCLR</name>
 		<description>DMA DMA channel source address decrement enable clear</description>
 		<addressOffset>0x0814</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHADRDECCLR</name>
@@ -6150,7 +6146,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMADSTADSET</name>
 		<description>DMA DMA channel destination address decrement enable set</description>
 		<addressOffset>0x0818</addressOffset>
-		<size>16</size>
+		
 		<fields>
                     <field>
                         <name>CHDSTADRDECSET</name>
@@ -6165,7 +6161,6 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>DMADSTADCLR</name>
 		<description>DMA DMA channel destination address decrement enable clear</description>
 		<addressOffset>0x081C</addressOffset>
-		<size>16</size>
 		<fields>
                     <field>
                         <name>CHADRDECCLR</name>
@@ -6180,13 +6175,14 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>DMAREVID</name>
 					<description>DMA DMA Controller Revision ID</description>
 					<addressOffset>0x0FE0</addressOffset>
+					<access>read-only</access>	
 					<size>8</size>
 				</register>
 			</registers>
 		</peripheral>
 		
 	<peripheral>
-	<name>ADI_FEE0</name>
+	<name>FEE0</name>
 	
 	<description>Instruction Flash Controller</description>
 	<groupName>IFC</groupName>
@@ -6208,62 +6204,57 @@ In the event that Third Party Software has only been provided to you in object c
 	<description>Flash EEPROM interrupt</description>
 	<value>55</value>
 	</interrupt>
+		<size>16</size>
+		<access>read-write</access>	
 		<registers>
 
 	<register>
 		<name>FEESTA</name>
 		<description>FEE0 Status</description>
 		<addressOffset>0x00</addressOffset>
-		<size>16</size>
+		<access>read-only</access>			
 	</register>
 
 	<register>
 		<name>FEECON0</name>
 		<description>FEE0 Command Control</description>
 		<addressOffset>0x04</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEECMD</name>
 		<description>FEE0 Command</description>
 		<addressOffset>0x08</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEADR0L</name>
 		<description>FEE0 Lower page address</description>
 		<addressOffset>0x10</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEADR0H</name>
 		<description>FEE0 Upper page address</description>
 		<addressOffset>0x14</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEADR1L</name>
 		<description>FEE0 Lower page address</description>
 		<addressOffset>0x18</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEADR1H</name>
 		<description>FEE0 Upper page address</description>
 		<addressOffset>0x1C</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEKEY</name>
 		<description>FEE0 Key</description>
 		<addressOffset>0x20</addressOffset>
-		<size>16</size>
 		<fields>
 				<field>
 					<name>KEY</name>
@@ -6293,90 +6284,78 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>FEESIGL</name>
 		<description>FEE0 Lower halfword of signature</description>
 		<addressOffset>0x30</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEESIGH</name>
 		<description>FEE0 Upper halfword of signature</description>
 		<addressOffset>0x34</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEADRAL</name>
 		<description>FEE0 Lower halfword of write abort address</description>
 		<addressOffset>0x48</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEADRAH</name>
 		<description>FEE0 Upper halfword of write abort address</description>
 		<addressOffset>0x4C</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEPARCTL</name>
 		<description>FEE0 Parity Control Register</description>
 		<addressOffset>0x50</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEPARSTA</name>
 		<description>FEE0 Parity Status Register</description>
 		<addressOffset>0x54</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEPARADRL</name>
 		<description>FEE0 Parity Error Address Low</description>
 		<addressOffset>0x58</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEPARADRH</name>
 		<description>FEE0 Parity Error Address High</description>
 		<addressOffset>0x5C</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEAEN0</name>
 		<description>FEE0 System IRQ abort enable for interrupts 15 to 0</description>
 		<addressOffset>0x78</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEAEN1</name>
 		<description>FEE0 System IRQ abort enable for interrupts 31 to 16</description>
 		<addressOffset>0x7C</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEAEN2</name>
 		<description>FEE0 System IRQ abort enable for interrupts 47 to 32</description>
 		<addressOffset>0x80</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>FEEAEN3</name>
 		<description>FEE0 System IRQ abort enable for interrupts 60 to 48</description>
 		<addressOffset>0x84</addressOffset>
-		<size>16</size>
 	</register>
 	</registers>
 	</peripheral>
 	
 	<peripheral>
-	<name>ADI_GPF</name>
+	<name>GPF</name>
 	
 	<description>General Purpose Flash Controller</description>
 	<groupName>GPFC</groupName>
@@ -6388,111 +6367,98 @@ In the event that Third Party Software has only been provided to you in object c
 	<size>0x88</size>
 	<usage>registers</usage>
 	</addressBlock>
-
+	<size>16</size>
+	<access>read-write</access>	
 	<registers>
 
 	<register>
 		<name>GPFEESTA</name>
 		<description>GPF Status</description>
 		<addressOffset>0x00</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEECON0</name>
 		<description>GPF Command Control</description>
 		<addressOffset>0x04</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEECMD</name>
 		<description>GPF Command</description>
 		<addressOffset>0x08</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEEADR0L</name>
 		<description>GPF Lower page address</description>
 		<addressOffset>0x10</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEEADR1L</name>
 		<description>GPF Lower page address</description>
 		<addressOffset>0x18</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEEKEY</name>
 		<description>GPF Key</description>
 		<addressOffset>0x20</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEESIGL</name>
 		<description>GPF Lower halfword of signature</description>
 		<addressOffset>0x30</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEESIGH</name>
 		<description>GPF Upper halfword of signature</description>
 		<addressOffset>0x34</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEEADRAL</name>
 		<description>GPF Lower halfword of write abort address</description>
 		<addressOffset>0x48</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEEADRAH</name>
 		<description>GPF Upper halfword of write abort address</description>
 		<addressOffset>0x4C</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEEAEN0</name>
 		<description>GPF System IRQ abort enable for interrupts 15 to 0</description>
 		<addressOffset>0x78</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEEAEN1</name>
 		<description>GPF System IRQ abort enable for interrupts 31 to 16</description>
 		<addressOffset>0x7C</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEEAEN2</name>
 		<description>GPF System IRQ abort enable for interrupts 47 to 32</description>
 		<addressOffset>0x80</addressOffset>
-		<size>16</size>
 	</register>
 
 	<register>
 		<name>GPFEEAEN3</name>
 		<description>GPF System IRQ abort enable for interrupts 60 to 48</description>
 		<addressOffset>0x84</addressOffset>
-		<size>16</size>
 	</register>
 	</registers>
 	</peripheral>
 	
 	<peripheral>
-	<name>ADI_GPIO0</name>
+	<name>GPIO0</name>
 	
 	<description>GPIO</description>
 	<groupName>GPIO</groupName>
@@ -6514,119 +6480,121 @@ In the event that Third Party Software has only been provided to you in object c
 	<name>GPIOB</name>
 	<description>interrupt</description>
 	<value>48</value>
-	</interrupt>	
+	</interrupt>
+		<size>32</size>
+		<access>read-write</access>
 		<registers>
 
 	<register>
 		<name>GPCON</name>
 		<description>GPIO0 GPIO Port 0 Configuration</description>
 		<addressOffset>0x00</addressOffset>
-		<size>16</size>
+		<size>32</size>		
 	</register>
 
 	<register>
 		<name>GPOEN</name>
 		<description>GPIO0 GPIO Port 0 output enable</description>
 		<addressOffset>0x04</addressOffset>
-		<size>16</size>
+		<size>16</size>			
 	</register>
 
 	<register>
 		<name>GPPE</name>
 		<description>GPIO0 GPIO Port 0 output pullup/pulldown enable</description>
 		<addressOffset>0x08</addressOffset>
-		<size>16</size>
+		<size>16</size>	
 	</register>
 
 	<register>
 		<name>GPIEN</name>
 		<description>GPIO0 GPIO Port 0 Input Path Enable</description>
 		<addressOffset>0x0C</addressOffset>
-		<size>16</size>
+		<size>16</size>	
 	</register>
 
 	<register>
 		<name>GPIN</name>
 		<description>GPIO0 GPIO Port 0 registered data input</description>
 		<addressOffset>0x10</addressOffset>
-		<size>16</size>
+		<size>16</size>	
 	</register>
 
 	<register>
 		<name>GPOUT</name>
 		<description>GPIO0 GPIO Port 0 data output</description>
 		<addressOffset>0x14</addressOffset>
-		<size>16</size>
+		<size>16</size>			
 	</register>
 
 	<register>
 		<name>GPSET</name>
 		<description>GPIO0 GPIO Port 0 data out set</description>
 		<addressOffset>0x18</addressOffset>
-		<size>16</size>
+		<size>16</size>			
 	</register>
 
 	<register>
 		<name>GPCLR</name>
 		<description>GPIO0 GPIO Port 0 data out clear</description>
 		<addressOffset>0x1C</addressOffset>
-		<size>16</size>
+		<size>16</size>			
 	</register>
 
 	<register>
 		<name>GPTGL</name>
 		<description>GPIO0 GPIO Port 0 pin toggle</description>
 		<addressOffset>0x20</addressOffset>
-		<size>16</size>
+		<size>16</size>			
 	</register>
 
 	<register>
 		<name>GPPOL</name>
 		<description>GPIO0 GPIO Port 0 interrupt polarity</description>
 		<addressOffset>0x24</addressOffset>
-		<size>16</size>
+		<size>16</size>			
 	</register>
 
 	<register>
 		<name>GPIENA</name>
 		<description>GPIO0 GPIO Port 0 interrupt A enable</description>
 		<addressOffset>0x28</addressOffset>
-		<size>16</size>
+		<size>16</size>	
 	</register>
 
 	<register>
 		<name>GPIENB</name>
 		<description>GPIO0 GPIO Port 0 interrupt B enable</description>
 		<addressOffset>0x2C</addressOffset>
-		<size>16</size>
+		<size>16</size>			
 	</register>
 
 	<register>
 		<name>GPINT</name>
 		<description>GPIO0 GPIO Port 0 interrupt Status</description>
 		<addressOffset>0x30</addressOffset>
-		<size>16</size>
+		<size>16</size>			
 	</register>
 	</registers>
 	</peripheral>
-	<peripheral derivedFrom=ADI_GPIO0>
-	<name>ADI_GPIO1</name>
+	<peripheral derivedFrom=GPIO0>
+	<name>GPIO1</name>
 	<baseAddress>0x40020040</baseAddress>
 	</peripheral>
-	<peripheral derivedFrom=ADI_GPIO0>
-	<name>ADI_GPIO2</name>
+	<peripheral derivedFrom=GPIO0>
+	<name>GPIO2</name>
 	<baseAddress>0x40020080</baseAddress>
 	</peripheral>	
-	<peripheral derivedFrom=ADI_GPIO0>
-	<name>ADI_GPIO3</name>
+	<peripheral derivedFrom=GPIO0>
+	<name>GPIO3</name>
 	<baseAddress>0x400200C0</baseAddress>
 	</peripheral>
-	<peripheral derivedFrom=ADI_GPIO0>
-	<name>ADI_GPIO4</name>
+	<peripheral derivedFrom=GPIO0>
+	<name>GPIO4</name>
 	<baseAddress>0x40020100</baseAddress>
 	</peripheral>
 	<peripheral>
-	<name>ADI_SPIH</name>
+	<name>SPIH0</name>
 	<description>SPIH Master/Slave</description>
 	<groupName>SPIH</groupName>
 	<baseAddress>0x40024000</baseAddress>
@@ -6643,9 +6611,11 @@ In the event that Third Party Software has only been provided to you in object c
 	<description>interrupt</description>
 	<value>16</value>
 	</interrupt>
+			<size>16</size>
+			<access>read-write</access>	
 				<registers>	
 				<register>
-					<name>SPISTA</name>
+					<name>SPIH0STA</name>
 					<description>SPIH Status</description>
 					<addressOffset>0x00</addressOffset>
 					<fields>
@@ -6763,10 +6733,10 @@ In the event that Third Party Software has only been provided to you in object c
 				</register>
 
 				<register>
-					<name>SPIRX</name>
+					<name>SPIH0RX</name>
 					<description>SPIH Receive</description>
 					<addressOffset>0x04</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>DMA</name>
@@ -6784,10 +6754,10 @@ In the event that Third Party Software has only been provided to you in object c
 				</register>
 
 				<register>
-					<name>SPITX</name>
+					<name>SPIH0TX</name>
 					<description>SPIH Transmit</description>
 					<addressOffset>0x08</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>DMA</name>
@@ -6805,10 +6775,10 @@ In the event that Third Party Software has only been provided to you in object c
 				</register>
 
 				<register>
-					<name>SPIDIV</name>
+					<name>SPIH0DIV</name>
 					<description>SPIH Baud rate selection</description>
 					<addressOffset>0x0C</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>CSIRQ</name>
@@ -6838,10 +6808,10 @@ In the event that Third Party Software has only been provided to you in object c
 				</register>
 
 				<register>
-					<name>SPICON</name>
+					<name>SPIH0CON</name>
 					<description>SPIH SPI configuration</description>
 					<addressOffset>0x10</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>MOD</name>
@@ -6997,10 +6967,10 @@ In the event that Third Party Software has only been provided to you in object c
 				</register>
 
 				<register>
-					<name>SPIDMA</name>
+					<name>SPIH0DMA</name>
 					<description>SPIH SPI DMA enable</description>
 					<addressOffset>0x14</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>IENRXDMA</name>
@@ -7060,10 +7030,10 @@ In the event that Third Party Software has only been provided to you in object c
 				</register>
 
 				<register>
-					<name>SPICNT</name>
+					<name>SPIH0CNT</name>
 					<description>SPIH Transfer byte count</description>
 					<addressOffset>0x18</addressOffset>
-					<size>16</size>
+					
 					<fields>
 						<field>
 							<name>COUNT</name>
@@ -7077,10 +7047,10 @@ In the event that Third Party Software has only been provided to you in object c
 	</peripheral>
 	
 	<peripheral>
-	<name>ADI_SYSCLK</name>
+	<name>SYSCLK</name>
 	
 	<description>System Clocking</description>
-	<groupName>SYSCLK</groupName>
+	<groupName>System Clocking</groupName>
 	<baseAddress>0x40028000</baseAddress>
 	<size>32</size>
 
@@ -7096,7 +7066,7 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>CLKCON0</name>
 		<description>Clock Control Register 0</description>
 		<addressOffset>0x00</addressOffset>
-		<size>16</size>
+		
 		<fields>
 			<field>
 				<name>HFXTALIE</name>
@@ -7188,7 +7158,7 @@ In the event that Third Party Software has only been provided to you in object c
 							</enumeratedValue>
 							<enumeratedValue>
 								<description>Cap Touch Clock</description>
-								<name>CT_CLK</name>
+								<name>CLK</name>
 								<value>2</value>
 							</enumeratedValue>
 							<enumeratedValue>
@@ -7279,44 +7249,44 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>CLKCON1</name>
 		<description>Clock Control Register 0</description>
 		<addressOffset>0x04</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
 		<name>CLKCON2</name>
 		<description>Clock Control Register 2</description>
 		<addressOffset>0x08</addressOffset>
-		<size>16</size>
+		
 	</register>
 	<register>
 		<name>CLKCON3</name>
 		<description>Clock Control Register 3</description>
 		<addressOffset>0x0c</addressOffset>
-		<size>16</size>
+		
 	</register>	
 	<register>
 		<name>CLKCON4</name>
 		<description>Clock Control Register 4</description>
 		<addressOffset>0x10</addressOffset>
-		<size>16</size>
+		
 	</register>		
 	<register>
 		<name>CLKCON5</name>
 		<description>Clock Control Register 5</description>
 		<addressOffset>0x14</addressOffset>
-		<size>16</size>
+		
 	</register>	
 	<register>
 		<name>CLKSTAT0</name>
 		<description>Clock Status Register 0</description>
 		<addressOffset>0x18</addressOffset>
-		<size>16</size>
+		
 	</register>	
 	</registers>
 	</peripheral>
 
 	<peripheral>
-	<name>ADI_CRC</name>
+	<name>CRC</name>
 	
 	<description>CRC Engine</description>
 	<groupName>CRCENG</groupName>
@@ -7335,27 +7305,27 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>CTL</name>
 		<description>CRC CRC Control Register</description>
 		<addressOffset>0x00</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
 		<name>IPDATA</name>
 		<description>CRC Input Data Register</description>
 		<addressOffset>0x04</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
 		<name>RESULT</name>
 		<description>CRC CRC Result Register</description>
 		<addressOffset>0x08</addressOffset>
-		<size>16</size>
+		
 	</register>
 	</registers>
 	</peripheral>
 	
 	<peripheral>
-	<name>ADI_PDI</name>
+	<name>PDI</name>
 	
 	<description>Parallel Display Interface</description>
 	<groupName>PDIC</groupName>
@@ -7379,28 +7349,28 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>CFG</name>
 		<description>PDI PDI Configuration Register</description>
 		<addressOffset>0x00</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
 		<name>INT_SET</name>
 		<description>PDI PDI Interrupt Set Register</description>
 		<addressOffset>0x04</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
 		<name>INT_CLR</name>
 		<description>PDI PDI Interrupt Clear Register</description>
 		<addressOffset>0x08</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
 		<name>STAT</name>
 		<description>PDI PDI Status Register</description>
 		<addressOffset>0x0C</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
@@ -7408,34 +7378,34 @@ In the event that Third Party Software has only been provided to you in object c
 		<name>CMD</name>
 		<description>PDI PDI Command Register</description>
 		<addressOffset>0x10</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
 		<name>FRDATA_N</name>
 		<description>PDI PDI Frame Data Count Register</description>
 		<addressOffset>0x14</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
 		<name>FIFO</name>
 		<description>PDI PDI Parameter FIFO</description>
 		<addressOffset>0x18</addressOffset>
-		<size>16</size>
+		
 	</register>
 
 	<register>
 		<name>IF_TIMING</name>
 		<description>PDI PDI Interface Timing Register</description>
 		<addressOffset>0x1C</addressOffset>
-		<size>16</size>
+		
 	</register>
 	</registers>
 	</peripheral>
 	
 	<peripheral>
-	<name>ADI_AFE</name>
+	<name>AFE</name>
 	
 	<description>Analog Front End</description>
 	<groupName>Analog Front End</groupName>
@@ -7449,22 +7419,22 @@ In the event that Third Party Software has only been provided to you in object c
 	</addressBlock>
 
 	<interrupt>
-	<name>AFE_CAPTURE</name>
+	<name>CAPTURE</name>
 	<description>Analog Front End Capture interrupt</description>
 	<value>50</value>
 	</interrupt>
 	<interrupt>
-	<name>AFE_GENERATE</name>
+	<name>GENERATE</name>
 	<description>Analog Front End Generation interrupt</description>
 	<value>51</value>
 	</interrupt>
 	<interrupt>
-	<name>AFE_CMD_FIFO</name>
+	<name>CMD_FIFO</name>
 	<description>Analog Front End FIFO CMD interrupt</description>
 	<value>52</value>
 	</interrupt>
 	<interrupt>
-		<name>AFE_DATA_FIFO</name>
+		<name>DATA_FIFO</name>
 		<description>Analog Front End FIFO DATA interrupt</description>
 		<value>53</value>
 	</interrupt>	
@@ -7864,10 +7834,10 @@ In the event that Third Party Software has only been provided to you in object c
 	</registers>
 	</peripheral>
 	<peripheral>
-		<name>ADI_CT</name>
+		<name>CT</name>
 		
 		<description>Cap Touch Controller</description>
-		<groupName>CT</groupName>
+		<groupName>Capacitive Touch</groupName>
 		<baseAddress>0x40084000</baseAddress>
 		<size>32</size>
 
@@ -7906,10 +7876,10 @@ In the event that Third Party Software has only been provided to you in object c
 	</peripheral>
 		
 	<peripheral>
-		<name>ADI_USB</name>
+		<name>USB</name>
 		
 		<description>USB Controller</description>
-		<groupName>USB</groupName>
+		<groupName>USB0</groupName>
 		<baseAddress>0x400A0000</baseAddress>
 		<size>32</size>
 
@@ -7935,686 +7905,686 @@ In the event that Third Party Software has only been provided to you in object c
 		</interrupt>
 		<registers>
 			<register>
-				<name>FADDR</name>
+				<name>USB0_FADDR</name>
 				<description>USB0 Function Address Register</description>
 				<addressOffset>0x00</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-				<name>POWER</name>
+				<name>USB0_POWER</name>
 				<description>USB0 Power and Device Control Register</description>
 				<addressOffset>0x01</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-				<name>INTRTX</name>
+				<name>USB0_INTRTX</name>
 				<description>USB0 Transmit Interrupt Register</description>
 				<addressOffset>0x02</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-				<name>INTRRX</name>
+				<name>USB0_INTRRX</name>
 				<description>USB0 Receive Interrupt Register</description>
 				<addressOffset>0x04</addressOffset>
 				<size>16</size>
 			</register>
 
 			<register>
-				<name>INTRTXE</name>
+				<name>USB0_INTRTXE</name>
 				<description>USB0 Transmit Interrupt Enable Register</description>
 				<addressOffset>0x0006</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>INTRRXE</name>
+				<name>USB0_INTRRXE</name>
 				<description>USB0 Receive Interrupt Enable Register</description>
 				<addressOffset>0x0008</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>IRQ</name>
+				<name>USB0_IRQ</name>
 				<description>USB0 Common Interrupts Register</description>
 				<addressOffset>0x000A</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-				<name>IEN</name>
+				<name>USB0_IEN</name>
 				<description>USB0 Common Interrupts Enable Register</description>
 				<addressOffset>0x000B</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-				<name>FRAME</name>
+				<name>USB0_FRAME</name>
 				<description>USB0 Frame Number Register</description>
 				<addressOffset>0x000C</addressOffset>
 				<size>16</size>
 			</register>
 
 			<register>
-				<name>INDEX</name>
+				<name>USB0_INDEX</name>
 				<description>USB0 Index Register</description>
 				<addressOffset>0x000E</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-				<name>TESTMODE</name>
+				<name>USB0_TESTMODE</name>
 				<description>USB0 Testmode Register</description>
 				<addressOffset>0x000F</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-				<name>EPI_TXMAXP0</name>
+				<name>USB0_EPI_TXMAXP0</name>
 				<description>USB0 EPn Transmit Maximum Packet Length Register</description>
 				<addressOffset>0x0010</addressOffset>
 				<size>16</size>
 			</register>
 <!--
 			<register>
-				<name>EPI_TXCSR_H0</name>
+				<name>USB0_EPI_TXCSR_H0</name>
 				<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
 				<addressOffset>0x0012</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 -->
 <!--
 			<register>
-				<name>EP0I_CSR0_P</name>
+				<name>USB0_EP0I_CSR0_P</name>
 				<description>USB0 EP0 Configuration and Status (Peripheral) Register</description>
 				<addressOffset>0x0012</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 -->
 <!--
 			<register>
-				<name>EP0I_CSR0_H</name>
+				<name>USB0_EP0I_CSR0_H</name>
 				<description>USB0 EP0 Configuration and Status (Host) Register</description>
 				<addressOffset>0x0012</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 -->
 			<register>
-				<name>EPI_TXCSR_P0</name>
+				<name>USB0_EPI_TXCSR_P0</name>
 				<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
 				<addressOffset>0x0012</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>EPI_RXMAXP0</name>
+				<name>USB0_EPI_RXMAXP0</name>
 				<description>USB0 EPn Receive Maximum Packet Length Register</description>
 				<addressOffset>0x0014</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 <!--
 			<register>
-				<name>EPI_RXCSR_H0</name>
+				<name>USB0_EPI_RXCSR_H0</name>
 				<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
 				<addressOffset>0x0016</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 -->
 <!--
 			<register>
-				<name>EPI_RXCSR_P0</name>
+				<name>USB0_EPI_RXCSR_P0</name>
 				<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
 				<addressOffset>0x0016</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 -->
 			<register>
-				<name>EP0I_CNT0</name>
+				<name>USB0_EP0I_CNT0</name>
 				<description>USB0 EP0 Number of Received Bytes Register</description>
 				<addressOffset>0x0018</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 <!--
 			<register>
-				<name>EPI_RXCNT0</name>
+				<name>USB0_EPI_RXCNT0</name>
 				<description>USB0 EPn Number of Bytes Received Register</description>
 				<addressOffset>0x0018</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 -->
 			<register>
-				<name>EP0I_CFGDATA0</name>
+				<name>USB0_EP0I_CFGDATA0</name>
 				<description>USB0 EP0 Configuration Information Register</description>
 				<addressOffset>0x001F</addressOffset>
 				<size>8</size>
 			</register>
 <!--
 			<register>
-				<name>EPI_FIFOSIZE0</name>
+				<name>USB0_EPI_FIFOSIZE0</name>
 				<description>USB0 FIFO size</description>
 				<addressOffset>0x001F</addressOffset>
 				<size>8</size>
 			</register>
 -->
 			<register>
-				<name>FIFO0</name>
+				<name>USB0_FIFO0</name>
 				<description>USB0 FIFO Word (32-Bit) Register</description>
 				<addressOffset>0x0020</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>FIFO1</name>
+				<name>USB0_FIFO1</name>
 				<description>USB0 FIFO Word (32-Bit) Register</description>
 				<addressOffset>0x0024</addressOffset>
-				<size>16</size>
+				<size>16</size>			
 			</register>
 
 			<register>
-				<name>FIFO2</name>
+				<name>USB0_FIFO2</name>
 				<description>USB0 FIFO Word (32-Bit) Register</description>
 				<addressOffset>0x0028</addressOffset>
 			</register>
 
 			<register>
-				<name>FIFO3</name>
+				<name>USB0_FIFO3</name>
 				<description>USB0 FIFO Word (32-Bit) Register</description>
 				<addressOffset>0x002C</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 <!--
 			<register>
-				<name>FIFOH0</name>
+				<name>USB0_FIFOH0</name>
 				<description>USB0 FIFO Half-Word (16-Bit) Register</description>
 				<addressOffset>0x0020</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>FIFOH1</name>
+				<name>USB0_FIFOH1</name>
 				<description>USB0 FIFO Half-Word (16-Bit) Register</description>
 				<addressOffset>0x0024</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>FIFOH2</name>
+				<name>USB0_FIFOH2</name>
 				<description>USB0 FIFO Half-Word (16-Bit) Register</description>
 				<addressOffset>0x0028</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>FIFOH3</name>
+				<name>USB0_FIFOH3</name>
 				<description>USB0 FIFO Half-Word (16-Bit) Register</description>
 				<addressOffset>0x002C</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 -->
 <!--
 			<register>
-				<name>FIFOB0</name>
+				<name>USB0_FIFOB0</name>
 				<description>USB0 FIFO Byte (8-Bit) Register</description>
 				<addressOffset>0x0020</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>FIFOB1</name>
+				<name>USB0_FIFOB1</name>
 				<description>USB0 FIFO Byte (8-Bit) Register</description>
 				<addressOffset>0x0024</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>FIFOB2</name>
+				<name>USB0_FIFOB2</name>
 				<description>USB0 FIFO Byte (8-Bit) Register</description>
 				<addressOffset>0x0028</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 
 			<register>
-				<name>FIFOB3</name>
+				<name>USB0_FIFOB3</name>
 				<description>USB0 FIFO Byte (8-Bit) Register</description>
 				<addressOffset>0x002C</addressOffset>
-				<size>16</size>
+				<size>16</size>				
 			</register>
 -->
 			<register>
-				<name>DEV_CTL</name>
+				<name>USB0_DEV_CTL</name>
 				<description>USB0 Device Control Register</description>
 				<addressOffset>0x0060</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-				<name>MISC</name>
+				<name>USB0_MISC</name>
 				<description>USB0 Miscellaneous Register</description>
 				<addressOffset>0x0061</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-				<name>EPINFO</name>
+				<name>USB0_EPINFO</name>
 				<description>USB0 Endpoint Information Register</description>
 				<addressOffset>0x0078</addressOffset>
 				<size>8</size>
 			</register>
 
 			<register>
-					<name>RAMINFO</name>
+					<name>USB0_RAMINFO</name>
 					<description>USB0 RAM Information Register</description>
 					<addressOffset>0x0079</addressOffset>
 					<size>8</size>
 				</register>
 
 				<register>
-					<name>LINKINFO</name>
+					<name>USB0_LINKINFO</name>
 					<description>USB0 Link Information Register</description>
 					<addressOffset>0x007A</addressOffset>
+					<size>16</size>					
+				</register>
+
+				<register>
+					<name>USB0_FS_EOF1</name>
+					<description>USB0 Full-Speed EOF 1 Register</description>
+					<addressOffset>0x007D</addressOffset>
+					<size>8</size>
 					<size>16</size>
 				</register>
 
 				<register>
-					<name>FS_EOF1</name>
-					<description>USB0 Full-Speed EOF 1 Register</description>
-					<addressOffset>0x007D</addressOffset>
-					<size>8</size>
-
-				</register>
-
-				<register>
-					<name>SOFT_RST</name>
+					<name>USB0_SOFT_RST</name>
 					<description>USB0 Software Reset Register</description>
 					<addressOffset>0x007F</addressOffset>
 					<size>8</size>
 				</register>
 
 				<register>
-					<name>EP0_TXMAXP</name>
+					<name>USB0_EP0_TXMAXP</name>
 					<description>USB0 EPn Transmit Maximum Packet Length Register</description>
 					<addressOffset>0x0100</addressOffset>
-					<size>16</size>
+					<size>16</size>					
 				</register>
 
 				<register>
-					<name>EP1_TXMAXP</name>
+					<name>USB0_EP1_TXMAXP</name>
 					<description>USB0 EPn Transmit Maximum Packet Length Register</description>
 					<addressOffset>0x0110</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP2_TXMAXP</name>
+					<name>USB0_EP2_TXMAXP</name>
 					<description>USB0 EPn Transmit Maximum Packet Length Register</description>
 					<addressOffset>0x0120</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP3_TXMAXP</name>
+					<name>USB0_EP3_TXMAXP</name>
 					<description>USB0 EPn Transmit Maximum Packet Length Register</description>
 					<addressOffset>0x0130</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP0_TXCSR_P</name>
+					<name>USB0_EP0_TXCSR_P</name>
 					<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
 					<addressOffset>0x0102</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP1_TXCSR_P</name>
+					<name>USB0_EP1_TXCSR_P</name>
 					<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
 					<addressOffset>0x0112</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP2_TXCSR_P</name>
+					<name>USB0_EP2_TXCSR_P</name>
 					<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
 					<addressOffset>0x0122</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP3_TXCSR_P</name>
+					<name>USB0_EP3_TXCSR_P</name>
 					<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
 					<addressOffset>0x0132</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 <!--
 				<register>
-					<name>EP0_CSR0_P</name>
+					<name>USB0_EP0_CSR0_P</name>
 					<description>USB0 EP0 Configuration and Status (Peripheral) Register</description>
 					<addressOffset>0x0102</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 <!--
 				<register>
-					<name>EP0_CSR0_H</name>
+					<name>USB0_EP0_CSR0_H</name>
 					<description>USB0 EP0 Configuration and Status (Host) Register</description>
 					<addressOffset>0x0102</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 <!--
 				<register>
-					<name>EP0_TXCSR_H</name>
+					<name>USB0_EP0_TXCSR_H</name>
 					<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
 					<addressOffset>0x0102</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 <!--
 				<register>
-					<name>EP1_TXCSR_H</name>
+					<name>USB0_EP1_TXCSR_H</name>
 					<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
 					<addressOffset>0x0112</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 <!--
 				<register>
-					<name>EP2_TXCSR_H</name>
+					<name>USB0_EP2_TXCSR_H</name>
 					<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
 					<addressOffset>0x0122</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 <!--
 				<register>
-					<name>EP3_TXCSR_H</name>
+					<name>USB0_EP3_TXCSR_H</name>
 					<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
 					<addressOffset>0x0132</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 
 				<register>
-					<name>EP0_RXMAXP</name>
+					<name>USB0_EP0_RXMAXP</name>
 					<description>USB0 EPn Receive Maximum Packet Length Register</description>
 					<addressOffset>0x0104</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP1_RXMAXP</name>
+					<name>USB0_EP1_RXMAXP</name>
 					<description>USB0 EPn Receive Maximum Packet Length Register</description>
 					<addressOffset>0x0114</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP2_RXMAXP</name>
+					<name>USB0_EP2_RXMAXP</name>
 					<description>USB0 EPn Receive Maximum Packet Length Register</description>
 					<addressOffset>0x0124</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP3_RXMAXP</name>
+					<name>USB0_EP3_RXMAXP</name>
 					<description>USB0 EPn Receive Maximum Packet Length Register</description>
 					<addressOffset>0x0134</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP0_RXCSR_P</name>
+					<name>USB0_EP0_RXCSR_P</name>
 					<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
 					<addressOffset>0x0106</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP1_RXCSR_P</name>
+					<name>USB0_EP1_RXCSR_P</name>
 					<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
 					<addressOffset>0x0116</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP2_RXCSR_P</name>
+					<name>USB0_EP2_RXCSR_P</name>
 					<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
 					<addressOffset>0x0126</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP3_RXCSR_P</name>
+					<name>USB0_EP3_RXCSR_P</name>
 					<description>USB0 EPn Receive Configuration and Status (Peripheral) Register</description>
 					<addressOffset>0x0136</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 <!--
 				<register>
-					<name>EP0_RXCSR_H</name>
+					<name>USB0_EP0_RXCSR_H</name>
 					<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
 					<addressOffset>0x0106</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 <!--
 				<register>
-					<name>EP1_RXCSR_H</name>
+					<name>USB0_EP1_RXCSR_H</name>
 					<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
 					<addressOffset>0x0116</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 <!--
 				<register>
-					<name>EP2_RXCSR_H</name>
+					<name>USB0_EP2_RXCSR_H</name>
 					<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
 					<addressOffset>0x0126</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 <!--
 				<register>
-					<name>EP3_RXCSR_H</name>
+					<name>USB0_EP3_RXCSR_H</name>
 					<description>USB0 EPn Receive Configuration and Status (Host) Register</description>
 					<addressOffset>0x0136</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 				<register>
-					<name>EP0_CNT0</name>
+					<name>USB0_EP0_CNT0</name>
 					<description>USB0 EP0 Number of Received Bytes Register</description>
 					<addressOffset>0x0108</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 <!--
 				<register>
-					<name>EP0_RXCNT</name>
+					<name>USB0_EP0_RXCNT</name>
 					<description>USB0 EPn Number of Bytes Received Register</description>
 					<addressOffset>0x0108</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 				<register>
-					<name>EP1_RXCNT</name>
+					<name>USB0_EP1_RXCNT</name>
 					<description>USB0 EPn Number of Bytes Received Register</description>
 					<addressOffset>0x0118</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP2_RXCNT</name>
+					<name>USB0_EP2_RXCNT</name>
 					<description>USB0 EPn Number of Bytes Received Register</description>
 					<addressOffset>0x0128</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP3_RXCNT</name>
+					<name>USB0_EP3_RXCNT</name>
 					<description>USB0 EPn Number of Bytes Received Register</description>
 					<addressOffset>0x0138</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 <!--
 				<register>
-					<name>EP0_FIFOSIZE</name>
+					<name>USB0_EP0_FIFOSIZE</name>
 					<description>USB0 FIFO size</description>
 					<addressOffset>0x010F</addressOffset>
-					<size>16</size>
+					<size>16</size>			
 				</register>
 
 				<register>
-					<name>EP1_FIFOSIZE</name>
+					<name>USB0_EP1_FIFOSIZE</name>
 					<description>USB0 FIFO size</description>
 					<addressOffset>0x011F</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP2_FIFOSIZE</name>
+					<name>USB0_EP2_FIFOSIZE</name>
 					<description>USB0 FIFO size</description>
 					<addressOffset>0x012F</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>EP3_FIFOSIZE</name>
+					<name>USB0_EP3_FIFOSIZE</name>
 					<description>USB0 FIFO size</description>
 					<addressOffset>0x013F</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 <!--
 				<register>
-					<name>EP0_CFGDATA0</name>
+					<name>USB0_EP0_CFGDATA0</name>
 					<description>USB0 EP0 Configuration Information Register</description>
 					<addressOffset>0x010F</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 -->
 				<register>
-					<name>DMA_IRQ</name>
+					<name>USB0_DMA_IRQ</name>
 					<description>USB0 DMA Interrupt Register</description>
 					<addressOffset>0x0200</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>DMA0_CTL</name>
+					<name>USB0_DMA0_CTL</name>
 					<description>USB0 DMA Channel n Control Register</description>
 					<addressOffset>0x0204</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>DMA1_CTL</name>
+					<name>USB0_DMA1_CTL</name>
 					<description>USB0 DMA Channel n Control Register</description>
 					<addressOffset>0x0214</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>DMA0_ADDR</name>
+					<name>USB0_DMA0_ADDR</name>
 					<description>USB0 DMA Channel n Address Register</description>
 					<addressOffset>0x0208</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>DMA1_ADDR</name>
+					<name>USB0_DMA1_ADDR</name>
 					<description>USB0 DMA Channel n Address Register</description>
 					<addressOffset>0x0218</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>DMA0_CNT</name>
+					<name>USB0_DMA0_CNT</name>
 					<description>USB0 DMA Channel n Count Register</description>
 					<addressOffset>0x020C</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>DMA1_CNT</name>
+					<name>USB0_DMA1_CNT</name>
 					<description>USB0 DMA Channel n Count Register</description>
 					<addressOffset>0x021C</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>RXDPKTBUFDIS</name>
+					<name>USB0_RXDPKTBUFDIS</name>
 					<description>USB0 RX Double Packet Buffer Disable for Endpoints 1 to 3</description>
 					<addressOffset>0x0340</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>TXDPKTBUFDIS</name>
+					<name>USB0_TXDPKTBUFDIS</name>
 					<description>USB0 TX Double Packet Buffer Disable for Endpoints 1 to 3</description>
 					<addressOffset>0x0342</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>CT_UCH</name>
+					<name>USB0_CT_UCH</name>
 					<description>USB0 Chirp Timeout Register</description>
 					<addressOffset>0x0344</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>LPM_ATTR</name>
+					<name>USB0_LPM_ATTR</name>
 					<description>USB0 LPM Attribute Register</description>
 					<addressOffset>0x0360</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>LPM_CTL</name>
+					<name>USB0_LPM_CTL</name>
 					<description>USB0 LPM Control Register</description>
 					<addressOffset>0x0362</addressOffset>
 					<size>8</size>
 				</register>
 
 				<register>
-					<name>LPM_IEN</name>
+					<name>USB0_LPM_IEN</name>
 					<description>USB0 LPM Interrupt Enable Register</description>
 					<addressOffset>0x0363</addressOffset>
 					<size>8</size>
 				</register>
 
 				<register>
-					<name>LPM_IRQ</name>
+					<name>USB0_LPM_IRQ</name>
 					<description>USB0 LPM Interrupt Status Register</description>
 					<addressOffset>0x0364</addressOffset>
 					<size>8</size>
 				</register>
 
 				<register>
-					<name>PHY_CTL</name>
+					<name>USB0_PHY_CTL</name>
 					<description>USB0 FS PHY Control</description>
 					<addressOffset>0x039C</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>PHY_STAT</name>
+					<name>USB0_PHY_STAT</name>
 					<description>USB0 FS PHY Status</description>
 					<addressOffset>0x039E</addressOffset>
-					<size>16</size>
+					<size>16</size>				
 				</register>
 
 				<register>
-					<name>RAM_ADDR</name>
+					<name>USB0_RAM_ADDR</name>
 					<description>USB0 RAM Address Register</description>
 					<addressOffset>0x03B0</addressOffset>
 					<size>32</size>
 				</register>
 
 				<register>
-					<name>RAM_DATA</name>
+					<name>USB0_RAM_DATA</name>
 					<description>USB0 RAM Data Register</description>
 					<addressOffset>0x03B4</addressOffset>
 					<size>32</size>

--- a/ADuCM350.svd
+++ b/ADuCM350.svd
@@ -368,6 +368,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>GPTCLRI</name>
 					<description>Clear interrupt register</description>
 					<addressOffset>0x0C</addressOffset>
+					<access>write-only</access>
 					<fields>
 						<field>
 							<name>CAP</name>
@@ -843,6 +844,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>GPTCLRI</name>
 					<description>Clear interrupt register</description>
 					<addressOffset>0x0C</addressOffset>
+					<access>write-only</access>					
 					<fields>
 						<field>
 							<name>CAP</name>
@@ -1298,6 +1300,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>GPTCLRI</name>
 					<description>Clear interrupt register</description>
 					<addressOffset>0x0C</addressOffset>
+					<access>write-only</access>					
 					<fields>
 						<field>
 							<name>CAP</name>
@@ -2749,6 +2752,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>T2CLRI</name>
 					<description>WUT Clear interrupt register</description>
 					<addressOffset>0x30</addressOffset>
+					<access>write-only</access>
 					<fields>
 						<field>
 							<name>ROLL</name>
@@ -2908,6 +2912,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>T3CLRI</name>
 					<description>WDT Clear interrupt register</description>
 					<addressOffset>0x0C</addressOffset>
+					<access>write-only</access>
 				</register>
 				<register>
 					<name>T3VALA</name>
@@ -3940,7 +3945,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>I2CSHCON</name>
 					<description>I2C Shared control</description>
 					<addressOffset>0x50</addressOffset>
-					
+					<access>write-only</access>
 					<fields>
 						<field>
 							<name>RESET</name>
@@ -4139,7 +4144,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPITX</name>
 					<description>SPI0 Transmit</description>
 					<addressOffset>0x08</addressOffset>
-					
+					<access>write-only</access>
 					<fields>
 						<field>
 							<name>DMA</name>
@@ -4533,7 +4538,7 @@ In the event that Third Party Software has only been provided to you in object c
 					<name>SPITX</name>
 					<description>SPI1 Transmit</description>
 					<addressOffset>0x08</addressOffset>
-					
+					<access>write-only</access>					
 					<fields>
 						<field>
 							<name>DMA</name>
@@ -7340,7 +7345,7 @@ In the event that Third Party Software has only been provided to you in object c
 
 	<interrupt>
 	<name>PDI</name>
-	<description>Paraller Display Interface interrupt</description>
+	<description>Parallel Display Interface interrupt</description>
 	<value>59</value>
 	</interrupt>
 		<registers>
@@ -7987,33 +7992,18 @@ In the event that Third Party Software has only been provided to you in object c
 				<addressOffset>0x0010</addressOffset>
 				<size>16</size>
 			</register>
-<!--
+
 			<register>
-				<name>USB0_EPI_TXCSR_H0</name>
-				<description>USB0 EPn Transmit Configuration and Status (Host) Register</description>
+				<name>USB0_EPI_TXCSR</name>
+				<description>USB0 EPn Transmit Configuration and Status Register</description>
 				<addressOffset>0x0012</addressOffset>
 				<size>16</size>				
 			</register>
--->
-<!--
+
 			<register>
-				<name>USB0_EP0I_CSR0_P</name>
-				<description>USB0 EP0 Configuration and Status (Peripheral) Register</description>
-				<addressOffset>0x0012</addressOffset>
-				<size>16</size>				
-			</register>
--->
-<!--
-			<register>
-				<name>USB0_EP0I_CSR0_H</name>
-				<description>USB0 EP0 Configuration and Status (Host) Register</description>
-				<addressOffset>0x0012</addressOffset>
-				<size>16</size>				
-			</register>
--->
-			<register>
-				<name>USB0_EPI_TXCSR_P0</name>
-				<description>USB0 EPn Transmit Configuration and Status (Peripheral) Register</description>
+				<name>USB0_EP0I_CSR0</name>
+				<alternateRegister>USB0_EPI_TXCSR</alternateRegister>				
+				<description>USB0 EP0 Configuration and Status Register</description>
 				<addressOffset>0x0012</addressOffset>
 				<size>16</size>				
 			</register>


### PR DESCRIPTION
ERROR M211: Ignoring EnumeratedValue : 'RESERVED'
ERROR M223: Input File Name does not match the tag <name> in the <device> section
ERROR M234: No valid items found for Peripheral
ERROR M302: Size of Register must be 8, 16 or 32 Bits
ERROR M305: Name not C compliant:
ERROR M324: Field does not fit into Register
ERROR M333: Duplicate <enumeratedValue>, already used by
ERROR M337: Enumerated Value already defined
ERROR M339: Register has same address or overlaps
ERROR M343: Peripheral has same address as
ERROR M344: Register  is outside or does not fit any <addressBlock> specified for Peripheral
ERROR M361: EnumeratedValue name 'RESERVED': 'RESERVED' items must not be defined.